### PR TITLE
rename

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -6,7 +6,7 @@ MAINTAINERCLEANFILES = $(srcdir)/Makefile.in \
 
 SUBDIRS = src examples
 
-pkgconfig_DATA = libdnstap.pc
+pkgconfig_DATA = libdnswire.pc
 
 dist_doc_DATA = README.md
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,9 @@
-# DNSTAP library
+# library for DNS encapsulations
 
-A C library that can read and write [DNSTAP](http://dnstap.info) and uses
-[tinyframe](https://github.com/DNS-OARC/tinyframe) to encapsulate it.
+**Currently Work in Progress!**
 
-Currently Work in Progress!
+A C library that can read and write different types of DNS and DNS transport
+encapsulations.
+
+Currently supports:
+- [DNSTAP](http://dnstap.info) over Frame Streams using [tinyframe](https://github.com/DNS-OARC/tinyframe)

--- a/configure.ac
+++ b/configure.ac
@@ -1,5 +1,5 @@
 AC_PREREQ(2.61)
-AC_INIT([dnstap], [0.1.0], [todo@dns-oarc.net], [dnstap], [https://github.com/DNS-OARC/dnstap/issues])
+AC_INIT([dnswire], [0.1.0], [admin@dns-oarc.net], [dnswire], [https://github.com/DNS-OARC/dnswire/issues])
 AM_INIT_AUTOMAKE([-Wall -Werror foreign subdir-objects])
 AC_CONFIG_SRCDIR([src/dnstap.c])
 AC_CONFIG_HEADER([src/config.h])
@@ -57,7 +57,7 @@ PKG_CHECK_MODULES([protobuf_c], [libprotobuf-c >= 1.0.1])
 # Output Makefiles
 AC_CONFIG_FILES([
   Makefile
-  libdnstap.pc
+  libdnswire.pc
   src/Makefile
   src/test/Makefile
   examples/Makefile

--- a/examples/Makefile.am
+++ b/examples/Makefile.am
@@ -12,23 +12,23 @@ noinst_PROGRAMS = simple_reader simple_writer simple_sender simple_receiver \
   multi_sender_uv
 
 simple_reader_SOURCES = simple_reader.c
-simple_reader_LDADD = ../src/libdnstap.la
+simple_reader_LDADD = ../src/libdnswire.la
 simple_reader_LDFLAGS = $(protobuf_c_LIBS) $(tinyframe_LIBS)
 
 simple_writer_SOURCES = simple_writer.c
-simple_writer_LDADD = ../src/libdnstap.la
+simple_writer_LDADD = ../src/libdnswire.la
 simple_writer_LDFLAGS = $(protobuf_c_LIBS) $(tinyframe_LIBS)
 
 simple_sender_SOURCES = simple_sender.c
-simple_sender_LDADD = ../src/libdnstap.la
+simple_sender_LDADD = ../src/libdnswire.la
 simple_sender_LDFLAGS = $(protobuf_c_LIBS) $(tinyframe_LIBS)
 
 simple_receiver_SOURCES = simple_receiver.c
-simple_receiver_LDADD = ../src/libdnstap.la
+simple_receiver_LDADD = ../src/libdnswire.la
 simple_receiver_LDFLAGS = $(protobuf_c_LIBS) $(tinyframe_LIBS)
 
 multi_sender_uv_SOURCES = multi_sender_uv.c
-multi_sender_uv_LDADD = ../src/libdnstap.la
+multi_sender_uv_LDADD = ../src/libdnswire.la
 multi_sender_uv_LDFLAGS = $(protobuf_c_LIBS) $(tinyframe_LIBS)
 
 endif

--- a/examples/simple_reader.c
+++ b/examples/simple_reader.c
@@ -1,4 +1,4 @@
-#include <dnstap/dnstap.h>
+#include <dnswire/dnstap.h>
 #include <tinyframe/tinyframe.h>
 
 #include <stdio.h>

--- a/fmt.sh
+++ b/fmt.sh
@@ -3,7 +3,7 @@
 clang-format-4.0 \
     -style=file \
     -i \
-    src/dnstap.c \
-    src/dnstap/dnstap.h \
+    src/*.c \
+    src/dnswire/*.h \
     src/test/*.c \
     examples/*.c

--- a/libdnswire.pc.in
+++ b/libdnswire.pc.in
@@ -3,11 +3,11 @@ exec_prefix=@exec_prefix@
 libdir=@libdir@
 includedir=@includedir@
 
-Name: libdnstap
-Description: dnstap library
+Name: libdnswire
+Description: dnswire library
 Version: @VERSION@
-URL: https://github.com/DNS-OARC/dnstap
+URL: https://github.com/DNS-OARC/dnswire
 Requires: libtinyframe >= 0.1.0
-Libs: -L${libdir} -ldnstap
+Libs: -L${libdir} -ldnswire
 Libs.private:
 Cflags: -I${includedir}

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -8,29 +8,29 @@ SUBDIRS = test
 AM_CFLAGS = -I$(tinyframe_CFLAGS) \
   -I$(protobuf_c_CFLAGS)
 
-lib_LTLIBRARIES = libdnstap.la
+lib_LTLIBRARIES = libdnswire.la
 
-libdnstap_la_SOURCES = dnstap.c
-nodist_libdnstap_la_SOURCES = dnstap.pb-c.c
-BUILT_SOURCES += dnstap/dnstap.pb-c.h
-nobase_include_HEADERS = dnstap/dnstap.h
-nobase_nodist_include_HEADERS = dnstap/dnstap.pb-c.h dnstap/dnstap-macros.h
-libdnstap_la_LDFLAGS = -ltinyframe -lprotobuf-c
+libdnswire_la_SOURCES = dnstap.c
+nodist_libdnswire_la_SOURCES = dnstap.pb-c.c
+BUILT_SOURCES += dnswire/dnstap.pb-c.h
+nobase_include_HEADERS = dnswire/dnstap.h
+nobase_nodist_include_HEADERS = dnswire/dnstap.pb-c.h dnswire/dnstap-macros.h
+libdnswire_la_LDFLAGS = -ltinyframe -lprotobuf-c
 
-CLEANFILES += $(nodist_libdnstap_la_SOURCES)
+CLEANFILES += $(nodist_libdnswire_la_SOURCES)
 EXTRA_DIST += dnstap.pb/dnstap.proto dnstap.pb/LICENSE dnstap.pb/README.md
 
-dnstap/dnstap.pb-c.h: dnstap.pb-c.c
-	mkdir -p dnstap/
-	cp dnstap.pb-c.h dnstap/
+dnswire/dnstap.pb-c.h: dnstap.pb-c.c
+	mkdir -p dnswire/
+	cp dnstap.pb-c.h dnswire/
 
 dnstap.pb-c.c: dnstap.pb/dnstap.proto
 	$(AM_V_GEN)@PROTOC_C@ "--c_out=." -I$(srcdir)/dnstap.pb $<
 
-BUILT_SOURCES += dnstap/dnstap-macros.h
+BUILT_SOURCES += dnswire/dnstap-macros.h
 EXTRA_DIST += gen-macros.sh dnstap.fields
 
-dnstap/dnstap-macros.h: dnstap.fields gen-macros.sh
+dnswire/dnstap-macros.h: dnstap.fields gen-macros.sh
 	$(AM_V_GEN)"$(srcdir)/gen-macros.sh" $< >$@
 
 CLEANFILES += $(BUILT_SOURCES)

--- a/src/dnstap.c
+++ b/src/dnstap.c
@@ -3,25 +3,25 @@
  * Copyright (c) 2019, OARC, Inc.
  * All rights reserved.
  *
- * This file is part of the dnstap library.
+ * This file is part of the dnswire library.
  *
- * dnstap library is free software: you can redistribute it and/or modify
+ * dnswire library is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
- * dnstap library is distributed in the hope that it will be useful,
+ * dnswire library is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU Lesser General Public License for more details.
  *
  * You should have received a copy of the GNU Lesser General Public License
- * along with dnstap library.  If not, see <http://www.gnu.org/licenses/>.
+ * along with dnswire library.  If not, see <http://www.gnu.org/licenses/>.
  */
 
 #include "config.h"
 
-#include "dnstap/dnstap.h"
+#include "dnswire/dnstap.h"
 
 const char const* DNSTAP_TYPE_STRING[] = {
     "UNKNOWN",

--- a/src/dnswire/dnstap.h
+++ b/src/dnswire/dnstap.h
@@ -3,23 +3,23 @@
  * Copyright (c) 2019, OARC, Inc.
  * All rights reserved.
  *
- * This file is part of the dnstap library.
+ * This file is part of the dnswire library.
  *
- * dnstap library is free software: you can redistribute it and/or modify
+ * dnswire library is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
- * dnstap library is distributed in the hope that it will be useful,
+ * dnswire library is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU Lesser General Public License for more details.
  *
  * You should have received a copy of the GNU Lesser General Public License
- * along with dnstap library.  If not, see <http://www.gnu.org/licenses/>.
+ * along with dnswire library.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-#include <dnstap/dnstap.pb-c.h>
+#include <dnswire/dnstap.pb-c.h>
 
 #include <stdint.h>
 #include <stdio.h>
@@ -80,7 +80,7 @@ struct dnstap {
         .unpacked_dnstap = 0,                     \
     }
 
-#include <dnstap/dnstap-macros.h>
+#include <dnswire/dnstap-macros.h>
 #define dnstap_type(d) (enum dnstap_type)((d).dnstap.type)
 #define dnstap_set_type(d, v)                     \
     switch (v) {                                  \

--- a/src/test/Makefile.am
+++ b/src/test/Makefile.am
@@ -13,11 +13,11 @@ TESTS = test1.sh test2.sh
 test1.sh: test1
 
 test1_SOURCES = test1.c
-test1_LDADD = ../libdnstap.la
+test1_LDADD = ../libdnswire.la
 test1_LDFLAGS = $(protobuf_c_LIBS) $(tinyframe_LIBS)
 
 test2.sh: test2 test1
 
 test2_SOURCES = test2.c
-test2_LDADD = ../libdnstap.la
+test2_LDADD = ../libdnswire.la
 test2_LDFLAGS = $(protobuf_c_LIBS) $(tinyframe_LIBS)

--- a/src/test/test1.c
+++ b/src/test/test1.c
@@ -1,4 +1,4 @@
-#include <dnstap/dnstap.h>
+#include <dnswire/dnstap.h>
 #include <tinyframe/tinyframe.h>
 
 #include <stdio.h>

--- a/src/test/test2.c
+++ b/src/test/test2.c
@@ -1,4 +1,4 @@
-#include <dnstap/dnstap.h>
+#include <dnswire/dnstap.h>
 #include <tinyframe/tinyframe.h>
 
 #include <arpa/inet.h>


### PR DESCRIPTION
- Rename library to `dnswire` to not be confused with the DNSTAP format