### PR TITLE
receiver, sender

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -1,0 +1,65 @@
+# Examples
+
+- `simple_reader`: Example of reading DNSTAP from a file and printing it's content
+- `simple_writer`: Example of constructing a DNSTAP message and writing it to a file
+- `simple_receiver`: Example of receiving a DNSTAP message over a TCP connection and printing it's content
+- `simple_sender`: Example of constructing a DNSTAP message and sending it over a TCP connection
+- `daemon_sender_uv`: Example of a daemon that will continuously send DNSTAP messages to connected clients, using the event engine `libuv`
+- `client_receiver_uv`: Example of a client that will receive DNSTAP message from the daemon, using the event engine `libuv`
+
+## simple_receiver and simple_sender
+
+These examples uses the way of connecting as implemented in the `fstrm`
+library, the receiver listens for connections by the sender and the
+sender connects to the receiver.
+
+```
+$ ./simple_receiver 127.0.0.1 5353
+socket
+bind
+listen
+accept
+received 42 bytes
+got control start
+got content type DNSTAP
+received 133 bytes
+---- dnstap
+identity: simple_writer
+version: 0.1.0
+message:
+  type: MESSAGE
+  query_time: 1574171725.103084765
+  response_time: 1574171725.103084973
+  socket_family: INET
+  socket_protocol: UDP
+  query_address: 127.0.0.1
+  query_port: 12345
+  response_address: 127.0.0.1
+  response_port: 53
+  query_message_length: 27
+  query_message: dns_wire_format_placeholder
+  response_message_length: 27
+  response_message: dns_wire_format_placeholder
+----
+received 12 bytes
+stopped
+```
+
+```
+$ ./simple_sender 127.0.0.1 5353
+socket
+connect
+sending control start and content type
+sent 42 bytes
+sending DNSTAP
+sent 133 bytes
+sending control stop
+sent 12 bytes
+```
+
+## daemon_sender_uv and client_receiver_uv
+
+These examples works in the reverse way compared to `simple_receiver` and
+`simple_sender`, and maybe a more traditional way, the daemon listens for
+connections and once a client connect it establish the Frame Streams to
+continuously send messages to the client.

--- a/examples/simple_reader.c
+++ b/examples/simple_reader.c
@@ -207,6 +207,7 @@ int main(int argc, const char* argv[])
      */
 
     if (tinyframe_read(&reader, decoding, left) != tinyframe_have_control_field
+        || reader.control_field.type != TINYFRAME_CONTROL_FIELD_CONTENT_TYPE
         || strncmp("protobuf:dnstap.Dnstap", (const char*)reader.control_field.data, reader.control_field.length)) {
         fprintf(stderr, "Not a control field, or not content type dnstap\n");
         return 1;

--- a/examples/simple_receiver.c
+++ b/examples/simple_receiver.c
@@ -1,5 +1,316 @@
-int main(void)
+#include <dnswire/dnstap.h>
+#include <tinyframe/tinyframe.h>
+
+#include <stdio.h>
+#include <errno.h>
+#include <string.h>
+#include <inttypes.h>
+#include <arpa/inet.h>
+#include <stdlib.h>
+#include <ctype.h>
+#include <sys/socket.h>
+#include <netinet/in.h>
+
+static const char* printable_string(const uint8_t* data, size_t len)
 {
-    // TODO
+    static char buf[512];
+    size_t      r = 0, w = 0;
+
+    while (r < len && w < sizeof(buf) - 1) {
+        if (isprint(data[r])) {
+            buf[w++] = data[r++];
+        } else {
+            if (w + 4 >= sizeof(buf) - 1) {
+                break;
+            }
+
+            sprintf(&buf[w], "\\x%02x", data[r++]);
+            w += 4;
+        }
+    }
+    if (w >= sizeof(buf)) {
+        buf[sizeof(buf) - 1] = 0;
+    } else {
+        buf[w] = 0;
+    }
+
+    return buf;
+}
+
+static const char* printable_ip_address(const uint8_t* data, size_t len)
+{
+    static char buf[INET6_ADDRSTRLEN];
+
+    buf[0] = 0;
+    if (len == 4) {
+        inet_ntop(AF_INET, data, buf, sizeof(buf));
+    } else if (len == 16) {
+        inet_ntop(AF_INET6, data, buf, sizeof(buf));
+    }
+
+    return buf;
+}
+
+static void print_dnstap(const uint8_t* data, size_t len_data)
+{
+    struct dnstap d = DNSTAP_INITIALIZER;
+
+    /*
+     * First we decode the DNSTAP protobuf message.
+     */
+
+    if (dnstap_decode_protobuf(&d, data, len_data)) {
+        fprintf(stderr, "dnstap_decode_protobuf() failed\n");
+        return;
+    }
+
+    printf("---- dnstap\n");
+
+    /*
+     * Now we can print the available information in the message.
+     */
+
+    if (dnstap_has_identity(d)) {
+        printf("identity: %s\n", printable_string(dnstap_identity(d), dnstap_identity_length(d)));
+    }
+    if (dnstap_has_version(d)) {
+        printf("version: %s\n", printable_string(dnstap_version(d), dnstap_version_length(d)));
+    }
+    if (dnstap_has_extra(d)) {
+        printf("extra: %s\n", printable_string(dnstap_extra(d), dnstap_extra_length(d)));
+    }
+
+    if (dnstap_type(d) == DNSTAP_TYPE_MESSAGE && dnstap_has_message(d)) {
+        printf("message:\n  type: %s\n", DNSTAP_TYPE_STRING[dnstap_type(d)]);
+
+        if (dnstap_message_has_query_time_sec(d) && dnstap_message_has_query_time_nsec(d)) {
+            printf("  query_time: %" PRIu64 ".%" PRIu32 "\n", dnstap_message_query_time_sec(d), dnstap_message_query_time_nsec(d));
+        }
+        if (dnstap_message_has_response_time_sec(d) && dnstap_message_has_response_time_nsec(d)) {
+            printf("  response_time: %" PRIu64 ".%" PRIu32 "\n", dnstap_message_response_time_sec(d), dnstap_message_response_time_nsec(d));
+        }
+        if (dnstap_message_has_socket_family(d)) {
+            printf("  socket_family: %s\n", DNSTAP_SOCKET_FAMILY_STRING[dnstap_message_socket_family(d)]);
+        }
+        if (dnstap_message_has_socket_protocol(d)) {
+            printf("  socket_protocol: %s\n", DNSTAP_SOCKET_PROTOCOL_STRING[dnstap_message_socket_protocol(d)]);
+        }
+        if (dnstap_message_has_query_address(d)) {
+            printf("  query_address: %s\n", printable_ip_address(dnstap_message_query_address(d), dnstap_message_query_address_length(d)));
+        }
+        if (dnstap_message_has_query_port(d)) {
+            printf("  query_port: %u\n", dnstap_message_query_port(d));
+        }
+        if (dnstap_message_has_response_address(d)) {
+            printf("  response_address: %s\n", printable_ip_address(dnstap_message_response_address(d), dnstap_message_response_address_length(d)));
+        }
+        if (dnstap_message_has_response_port(d)) {
+            printf("  response_port: %u\n", dnstap_message_response_port(d));
+        }
+        if (dnstap_message_has_query_zone(d)) {
+            printf("  query_zone: %s\n", printable_string(dnstap_message_query_zone(d), dnstap_message_query_zone_length(d)));
+        }
+        if (dnstap_message_has_query_message(d)) {
+            printf("  query_message_length: %lu\n", dnstap_message_query_message_length(d));
+            printf("  query_message: %s\n", printable_string(dnstap_message_query_message(d), dnstap_message_query_message_length(d)));
+        }
+        if (dnstap_message_has_response_message(d)) {
+            printf("  response_message_length: %lu\n", dnstap_message_response_message_length(d));
+            printf("  response_message: %s\n", printable_string(dnstap_message_response_message(d), dnstap_message_response_message_length(d)));
+        }
+    }
+
+    printf("----\n");
+
+    /*
+     * And finally we cleanup protobuf allocations.
+     */
+
+    dnstap_cleanup(&d);
+}
+
+void handle_client(int fd)
+{
+    /*
+     * As we will be receiving we need to support getting half a frame
+     * and continuing on that so we do a loop where we call
+     * `tinyframe_read()` and when it says it needs more bytes we do
+     * a `recv()` on the socket.
+     *
+     * As we call `tinyframe_read()` the first time without any data
+     * (`have` == 0) it will return that it needs more.
+     */
+
+    struct tinyframe_reader reader = TINYFRAME_READER_INITIALIZER;
+
+    ssize_t               r;
+    size_t                have = 0;
+    uint8_t               buf[4096];
+    enum tinyframe_result res;
+
+    while (1) {
+        switch ((res = tinyframe_read(&reader, buf, have))) {
+        case tinyframe_have_control:
+            /*
+             * If we get a control frame we check that it's a start one,
+             * this code can be extended with checks that you only get one
+             * start frame and it's the first you get.
+             */
+            if (reader.control.type != TINYFRAME_CONTROL_START) {
+                fprintf(stderr, "Not a control type start\n");
+                return;
+            }
+            printf("got control start\n");
+            break;
+
+        case tinyframe_have_control_field:
+            /*
+             * We have a control field, so lets check that it's a
+             * `content type` and the content we want is
+             * `protobuf:dnstap.Dnstap`.
+             */
+            if (reader.control_field.type != TINYFRAME_CONTROL_FIELD_CONTENT_TYPE
+                || strncmp("protobuf:dnstap.Dnstap", (const char*)reader.control_field.data, reader.control_field.length)) {
+                fprintf(stderr, "Not content type dnstap\n");
+                return;
+            }
+            printf("got content type DNSTAP\n");
+            break;
+
+        case tinyframe_have_frame:
+            /*
+             * We got a frame, lets use `print_dnstap()` to decode the
+             * DNSTAP content.
+             */
+            print_dnstap(reader.frame.data, reader.frame.length);
+            break;
+
+        case tinyframe_need_more:
+            /*
+             * We need more bytes! Let's try and receive some.
+             *
+             * NOTE: This will add bytes to those we already have.
+             */
+            if (have >= sizeof(buf)) {
+                fprintf(stderr, "needed more but buffer was full\n");
+                return;
+            }
+
+            if ((r = recv(fd, &buf[have], sizeof(buf) - have, 0)) < 1) {
+                if (r < 0) {
+                    fprintf(stderr, "read() failed: %s\n", strerror(errno));
+                }
+                return;
+            }
+
+            printf("received %zd bytes\n", r);
+            have += r;
+            break;
+
+        case tinyframe_error:
+            fprintf(stderr, "tinyframe_read() error\n");
+            return;
+
+        case tinyframe_stopped:
+            printf("stopped\n");
+            return;
+
+        case tinyframe_finished:
+            printf("finished\n");
+            return;
+        }
+
+        /*
+         * If we processed any content in the buffer we might have some left
+         * so we move what's left to the start of the buffer.
+         */
+        if (res != tinyframe_need_more) {
+            if (reader.bytes_read > have) {
+                fprintf(stderr, "tinyframe problem, bytes processed more then we had\n");
+                return;
+            }
+
+            have -= reader.bytes_read;
+
+            if (have) {
+                memmove(buf, &buf[reader.bytes_read], have);
+            }
+        }
+    }
+}
+
+int main(int argc, const char* argv[])
+{
+    if (argc < 2) {
+        fprintf(stderr, "usage: simple_receiver <IP> <port>\n");
+        return 1;
+    }
+
+    /*
+     * We setup and listen on the IP and port given on command line.
+     */
+
+    struct sockaddr_storage addr_store;
+    struct sockaddr_in*     addr = (struct sockaddr_in*)&addr_store;
+    socklen_t               addrlen;
+
+    if (strchr(argv[1], ':')) {
+        addr->sin_family = AF_INET6;
+        addrlen          = sizeof(struct sockaddr_in6);
+    } else {
+        addr->sin_family = AF_INET;
+        addrlen          = sizeof(struct sockaddr_in);
+    }
+
+    if (inet_pton(addr->sin_family, argv[1], &addr->sin_addr) != 1) {
+        fprintf(stderr, "inet_pton(%s) failed: %s\n", argv[1], strerror(errno));
+        return 1;
+    }
+
+    addr->sin_port = atoi(argv[2]);
+
+    int sockfd = socket(addr->sin_family, SOCK_STREAM, IPPROTO_TCP);
+    if (sockfd == -1) {
+        fprintf(stderr, "socket() failed: %s\n", strerror(errno));
+        return 1;
+    }
+    printf("socket\n");
+
+    if (bind(sockfd, (struct sockaddr*)addr, addrlen)) {
+        fprintf(stderr, "bind() failed: %s\n", strerror(errno));
+        close(sockfd);
+        return 1;
+    }
+    printf("bind\n");
+
+    if (listen(sockfd, 0)) {
+        fprintf(stderr, "listen() failed: %s\n", strerror(errno));
+        close(sockfd);
+        return 1;
+    }
+    printf("listen\n");
+
+    int clifd = accept(sockfd, 0, 0);
+    if (clifd < 0) {
+        fprintf(stderr, "accept() failed: %s\n", strerror(errno));
+        close(sockfd);
+        return 1;
+    }
+    printf("accept\n");
+
+    /*
+     * We have accepted connection from the sender!
+     */
+
+    handle_client(clifd);
+
+    /*
+     * Time to exit, let's shutdown and close the sockets.
+     */
+
+    shutdown(clifd, SHUT_RDWR);
+    close(clifd);
+    close(sockfd);
+
     return 0;
 }

--- a/examples/simple_sender.c
+++ b/examples/simple_sender.c
@@ -1,5 +1,254 @@
-int main(void)
+#include <dnswire/dnswire.h>
+#include <dnswire/dnstap.h>
+#include <tinyframe/tinyframe.h>
+
+#include <arpa/inet.h>
+#include <time.h>
+#include <errno.h>
+#include <stdio.h>
+#include <string.h>
+#include <stdlib.h>
+
+static char dns_wire_format_placeholder[] = "dns_wire_format_placeholder";
+static char content_type[]                = "protobuf:dnstap.Dnstap";
+
+int send_frame(int fd, const char* buf, size_t len)
 {
-    // TODO
+    size_t  sent = 0;
+    ssize_t w;
+
+    while (sent < len) {
+        if ((w = send(fd, &buf[sent], len - sent, 0)) < 1) {
+            if (w < 0) {
+                fprintf(stderr, "write() failed: %s\n", strerror(errno));
+            }
+            return 1;
+        }
+
+        printf("sent %zd bytes\n", w);
+
+        sent += w;
+    }
+
+    return 0;
+}
+
+void handle_client(int fd)
+{
+    /*
+     * We now create each of the needed frames and sends them one by one.
+     */
+
+    struct tinyframe_writer writer = TINYFRAME_WRITER_INITIALIZER;
+
+    /*
+     * We create a buffer that holds a control frame, we do not need to
+     * hold the data in this buffer because we will use the data buffer
+     * for that.
+     */
+
+    uint8_t out[TINYFRAME_CONTROL_FRAME_LENGTH_MAX];
+    size_t  len = sizeof(out);
+
+    /*
+     * First we write, to the buffer, a control start with a content type
+     * control field for the DNSTAP protobuf content type.
+     *
+     * Then we send it.
+     */
+
+    if (tinyframe_write_control_start(&writer, out, len, content_type, sizeof(content_type) - 1) != tinyframe_ok) {
+        fprintf(stderr, "tinyframe_write_control_start() failed\n");
+        return;
+    }
+    printf("sending control start and content type\n");
+    if (send_frame(fd, out, writer.bytes_wrote)) {
+        return;
+    }
+
+    /*
+     * Now we initialize a DNSTAP message.
+     */
+
+    struct dnstap d = DNSTAP_INITIALIZER;
+
+    /*
+     * DNSTAP has a header with information about who constructed the
+     * message.
+     */
+
+    dnstap_set_identity_string(d, "simple_writer");
+    dnstap_set_version_string(d, DNSWIRE_VERSION_STRING);
+
+    /*
+     * Now we specify that this is a DNSTAP message, this is the one that
+     * holds the DNS.
+     */
+
+    dnstap_set_type(d, DNSTAP_TYPE_MESSAGE);
+
+    /*
+     * The message can have different types, we specify this is a query
+     * made by a tool.
+     */
+
+    dnstap_message_set_type(d, DNSTAP_MESSAGE_TYPE_TOOL_QUERY);
+
+    /*
+     * As most DNS comes over the network we can specify over what protocol,
+     * where from, to whom it came to and when it happened.
+     *
+     * Even if all fields are optional and there is no restriction on how
+     * many or how few you set, there is a recommended way of filling in
+     * the messages based on the message type.
+     *
+     * Please see the description of this at the bottom of
+     * `src/dnstap.pb/dnstap.proto` or
+     * <https://github.com/dnstap/dnstap.pb/blob/master/dnstap.proto>.
+     */
+
+    dnstap_message_set_socket_family(d, DNSTAP_SOCKET_FAMILY_INET);
+    dnstap_message_set_socket_protocol(d, DNSTAP_SOCKET_PROTOCOL_UDP);
+
+    unsigned char query_address[sizeof(struct in_addr)];
+    if (inet_pton(AF_INET, "127.0.0.1", query_address) != 1) {
+        fprintf(stderr, "inet_pton(127.0.0.1) failed: %s\n", strerror(errno));
+        return;
+    }
+    dnstap_message_set_query_address(d, query_address, sizeof(query_address));
+    dnstap_message_set_query_port(d, 12345);
+
+    struct timespec query_time = { 0, 0 };
+    clock_gettime(CLOCK_REALTIME, &query_time);
+    dnstap_message_set_query_time_sec(d, query_time.tv_sec);
+    dnstap_message_set_query_time_nsec(d, query_time.tv_nsec);
+
+    unsigned char response_address[sizeof(struct in_addr)];
+    if (inet_pton(AF_INET, "127.0.0.1", response_address) != 1) {
+        fprintf(stderr, "inet_pton(127.0.0.1) failed: %s\n", strerror(errno));
+        return;
+    }
+    dnstap_message_set_response_address(d, response_address, sizeof(response_address));
+    dnstap_message_set_response_port(d, 53);
+
+    struct timespec response_time = { 0, 0 };
+    clock_gettime(CLOCK_REALTIME, &response_time);
+    dnstap_message_set_response_time_sec(d, response_time.tv_sec);
+    dnstap_message_set_response_time_nsec(d, response_time.tv_nsec);
+
+    /*
+     * If we also had the DNS wire format we could use it, now we fill it
+     * with a placeholder text.
+     *
+     * NOTE: This will be invalid DNS if the output file is used with a
+     *       tool that uses the DNS messages.
+     */
+
+    dnstap_message_set_query_message(d, dns_wire_format_placeholder, sizeof(dns_wire_format_placeholder) - 1);
+
+    dnstap_message_set_response_message(d, dns_wire_format_placeholder, sizeof(dns_wire_format_placeholder) - 1);
+
+    /*
+     * Now that the message is prepared we can begin encapsulating it in
+     * protobuf and Frame Streams.
+     *
+     * First we ask what the encoded size of the protobuf message would be
+     * and then we allocate a buffer with of that size plus the size of
+     * a Frame Streams frame header.
+     *
+     * Then we encode the DNSTAP message and put it after the frame header
+     * and call `tinyframe_set_header()` to set the header.
+     */
+
+    size_t  frame_len = dnstap_encode_protobuf_size(&d);
+    uint8_t frame[TINYFRAME_HEADER_SIZE + frame_len];
+    dnstap_encode_protobuf(&d, &frame[TINYFRAME_HEADER_SIZE]);
+    tinyframe_set_header(frame, frame_len);
+
+    /*
+     * Then we write, to the buffer, the data frame with the encoded DNSTAP
+     * message and the included Frame Streams header.
+     *
+     * Then we send it.
+     */
+
+    printf("sending DNSTAP\n");
+    if (send_frame(fd, frame, sizeof(frame))) {
+        return;
+    }
+
+    /*
+     * Lastly we write, to the buffer, a control stop to indicate the end.
+     *
+     * Then we send it.
+     */
+
+    if (tinyframe_write_control_stop(&writer, out, len) != tinyframe_ok) {
+        fprintf(stderr, "tinyframe_write_control_stop() failed\n");
+        return;
+    }
+    printf("sending control stop\n");
+    if (send_frame(fd, out, writer.bytes_wrote)) {
+        return;
+    }
+}
+
+int main(int argc, const char* argv[])
+{
+    if (argc < 2) {
+        fprintf(stderr, "usage: simple_receiver <IP> <port>\n");
+        return 1;
+    }
+
+    /*
+     * We setup and connect to the IP and port given on command line.
+     */
+
+    struct sockaddr_storage addr_store;
+    struct sockaddr_in*     addr = (struct sockaddr_in*)&addr_store;
+    socklen_t               addrlen;
+
+    if (strchr(argv[1], ':')) {
+        addr->sin_family = AF_INET6;
+        addrlen          = sizeof(struct sockaddr_in6);
+    } else {
+        addr->sin_family = AF_INET;
+        addrlen          = sizeof(struct sockaddr_in);
+    }
+
+    if (inet_pton(addr->sin_family, argv[1], &addr->sin_addr) != 1) {
+        fprintf(stderr, "inet_pton(%s) failed: %s\n", argv[1], strerror(errno));
+        return 1;
+    }
+
+    addr->sin_port = atoi(argv[2]);
+
+    int sockfd = socket(addr->sin_family, SOCK_STREAM, IPPROTO_TCP);
+    if (sockfd == -1) {
+        fprintf(stderr, "socket() failed: %s\n", strerror(errno));
+        return 1;
+    }
+    printf("socket\n");
+
+    if (connect(sockfd, (struct sockaddr*)addr, addrlen)) {
+        fprintf(stderr, "connect() failed: %s\n", strerror(errno));
+        close(sockfd);
+        return 1;
+    }
+    printf("connect\n");
+
+    /*
+     * We are now connected!
+     */
+
+    handle_client(sockfd);
+
+    /*
+     * Time to exit, let's shutdown and close the sockets.
+     */
+
+    shutdown(sockfd, SHUT_RDWR);
+    close(sockfd);
+
     return 0;
 }

--- a/examples/simple_writer.c
+++ b/examples/simple_writer.c
@@ -126,7 +126,7 @@ int main(int argc, const char* argv[])
      * Next we initialize a tinyframe writer to write out the Frame Streams.
      */
 
-    struct tinyframe_writer h = TINYFRAME_WRITER_INITIALIZER;
+    struct tinyframe_writer writer = TINYFRAME_WRITER_INITIALIZER;
 
     /*
      * We create a buffer that holds the control frames and the data frame,
@@ -143,35 +143,35 @@ int main(int argc, const char* argv[])
      * control field for the DNSTAP protobuf content type.
      */
 
-    if (tinyframe_write_control_start(&h, &out[wrote], len, content_type, sizeof(content_type) - 1) != tinyframe_ok) {
+    if (tinyframe_write_control_start(&writer, &out[wrote], len, content_type, sizeof(content_type) - 1) != tinyframe_ok) {
         fprintf(stderr, "tinyframe_write_control_start() failed\n");
         return 1;
     }
-    wrote += h.bytes_wrote;
-    len -= h.bytes_wrote;
+    wrote += writer.bytes_wrote;
+    len -= writer.bytes_wrote;
 
     /*
-     * The we write, to the buffer, a data frame with the encoded DNSTAP
+     * Then we write, to the buffer, a data frame with the encoded DNSTAP
      * message.
      */
 
-    if (tinyframe_write_frame(&h, &out[wrote], len, frame, sizeof(frame)) != tinyframe_ok) {
+    if (tinyframe_write_frame(&writer, &out[wrote], len, frame, sizeof(frame)) != tinyframe_ok) {
         fprintf(stderr, "tinyframe_write_frame() failed\n");
         return 1;
     }
-    wrote += h.bytes_wrote;
-    len -= h.bytes_wrote;
+    wrote += writer.bytes_wrote;
+    len -= writer.bytes_wrote;
 
     /*
      * Lastly we write, to the buffer, a control stop to indicate the end.
      */
 
-    if (tinyframe_write_control_stop(&h, &out[wrote], len) != tinyframe_ok) {
+    if (tinyframe_write_control_stop(&writer, &out[wrote], len) != tinyframe_ok) {
         fprintf(stderr, "tinyframe_write_control_stop() failed\n");
         return 1;
     }
-    wrote += h.bytes_wrote;
-    len -= h.bytes_wrote;
+    wrote += writer.bytes_wrote;
+    len -= writer.bytes_wrote;
 
     /*
      * Now we write the buffer to the file we opened previously.


### PR DESCRIPTION
- Add examples README
- Add `examples/simple_receiver`
- Add `examples/simple_sender`
- `examples/simple_writer`:
  - Rename the variable name for `struct tinyframe_writer` to be more clearer
  - Correct type in comment
- `examples/simple_reader`: Add check for control content field type