### PR TITLE
examples, reader, writer

### DIFF
--- a/examples/Makefile.am
+++ b/examples/Makefile.am
@@ -12,14 +12,20 @@ EXTRA_DIST = print_dnstap.c create_dnstap.c
 
 if BUILD_EXAMPLES
 
-noinst_PROGRAMS = reader writer simple_reader simple_writer simple_sender \
-  simple_receiver
+noinst_PROGRAMS = reader writer sender receiver simple_reader simple_writer \
+  simple_sender simple_receiver
 
 reader_SOURCES = reader.c
 reader_LDADD = ../src/libdnswire.la
 
 writer_SOURCES = writer.c
 writer_LDADD = ../src/libdnswire.la
+
+sender_SOURCES = sender.c
+sender_LDADD = ../src/libdnswire.la
+
+receiver_SOURCES = receiver.c
+receiver_LDADD = ../src/libdnswire.la
 
 simple_reader_SOURCES = simple_reader.c
 simple_reader_LDADD = ../src/libdnswire.la

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,13 +1,15 @@
 # Examples
 
-- `simple_reader`: Example of reading DNSTAP from a file and printing it's content
-- `simple_writer`: Example of constructing a DNSTAP message and writing it to a file
-- `simple_receiver`: Example of receiving a DNSTAP message over a TCP connection and printing it's content
-- `simple_sender`: Example of constructing a DNSTAP message and sending it over a TCP connection
-- `daemon_sender_uv`: Example of a daemon that will continuously send DNSTAP messages to connected clients, using the event engine `libuv`
-- `client_receiver_uv`: Example of a client that will receive DNSTAP message from the daemon, using the event engine `libuv`
+- `simple_reader`: Example of reading DNSTAP from a file and printing it's content, using `dnswire_reader`
+- `simple_writer`: Example of constructing a DNSTAP message and writing it to a file, using `dnswire_writer`
+- `simple_receiver`: Example of receiving a DNSTAP message over a TCP connection and printing it's content, using `dnswire_reader`
+- `simple_sender`: Example of constructing a DNSTAP message and sending it over a TCP connection, using `dnswire_writer`
+- `daemon_sender_uv`: Example of a daemon that will continuously send DNSTAP messages to connected clients, using the event engine `libuv` and `dnstap_encode_protobuf` along with `tinyframe` to encode once and send to many
+- `client_receiver_uv`: Example of a client that will receive DNSTAP message from the daemon, using the event engine `libuv` and `dnswire_reader`
 - `reader`: Example of reading DNSTAP using `tinyframe` to show how Frame Streams work
 - `writer`: Example of writing DNSTAP using `tinyframe` to show how Frame Streams work
+- `receiver`: Example of receiving a DNSTAP message over a TCP connection and printing it's content, using `tinyframe` to show how Frame Streams work
+- `sender`: Example of constructing a DNSTAP message and sending it over a TCP connection, using `tinyframe` to show how Frame Streams work
 
 ## simple_receiver and simple_sender
 
@@ -21,17 +23,14 @@ socket
 bind
 listen
 accept
-received 42 bytes
-got control start
-got content type DNSTAP
-received 133 bytes
+receiving...
 ---- dnstap
 identity: simple_sender
 version: 0.1.0
 message:
   type: MESSAGE
-  query_time: 1574171725.103084765
-  response_time: 1574171725.103084973
+  query_time: 1574765731.199945162
+  response_time: 1574765731.199945362
   socket_family: INET
   socket_protocol: UDP
   query_address: 127.0.0.1
@@ -43,7 +42,6 @@ message:
   response_message_length: 27
   response_message: dns_wire_format_placeholder
 ----
-received 12 bytes
 stopped
 ```
 
@@ -51,12 +49,9 @@ stopped
 $ ./simple_sender 127.0.0.1 5353
 socket
 connect
-sending control start and content type
-sent 42 bytes
-sending DNSTAP
-sent 133 bytes
-sending control stop
-sent 12 bytes
+sending...
+sent, stopping...
+stopped
 ```
 
 ## daemon_sender_uv and client_receiver_uv

--- a/examples/client_receiver_uv.c
+++ b/examples/client_receiver_uv.c
@@ -1,6 +1,4 @@
-#include <dnswire/dnswire.h>
-#include <dnswire/dnstap.h>
-#include <tinyframe/tinyframe.h>
+#include <dnswire/reader.h>
 
 #include <stdio.h>
 #include <stdlib.h>
@@ -15,133 +13,52 @@
 
 #define BUF_SIZE 4096
 
-uv_loop_t*              loop;
-uv_tcp_t                sock;
-uv_connect_t            conn;
-uint8_t                 rbuf[BUF_SIZE];
-size_t                  have   = 0;
-struct tinyframe_reader reader = TINYFRAME_READER_INITIALIZER;
+uv_loop_t*   loop;
+uv_tcp_t     sock;
+uv_connect_t conn;
+char         rbuf[BUF_SIZE];
+
+struct dnswire_reader reader = DNSWIRE_READER_INITIALIZER;
 
 void client_alloc_buffer(uv_handle_t* handle, size_t suggested_size, uv_buf_t* buf)
 {
-    buf->base = (char*)&rbuf[have];
-    buf->len  = BUF_SIZE - have;
+    buf->base = rbuf;
+    buf->len  = sizeof(rbuf);
 }
 
 void client_read(uv_stream_t* handle, ssize_t nread, const uv_buf_t* buf)
 {
     if (nread > 0) {
-        printf("received %zd bytes\n", nread);
-        have += nread;
-
         /*
-         * We now process the frames we have in the buffer.
+         * We now push all the data we got to the reader.
          */
+        size_t pushed = 0;
 
-        while (1) {
-            switch (tinyframe_read(&reader, rbuf, have)) {
-            case tinyframe_have_control:
+        while (pushed < nread) {
+            enum dnswire_result res = dnswire_reader_push(&reader, (uint8_t*)&buf->base[pushed], nread - pushed);
+
+            pushed += dnswire_reader_pushed(reader);
+
+            switch (res) {
+            case dnswire_have_dnstap:
                 /*
-                 * If we get a control frame we check that it's a start one,
-                 * this code can be extended with checks that you only get one
-                 * start frame and it's the first you get.
+                 * We got a DNSTAP message, lets print it!
                  */
-                if (reader.control.type != TINYFRAME_CONTROL_START) {
-                    fprintf(stderr, "Not a control type start\n");
-                    uv_close((uv_handle_t*)handle, 0);
-                    return;
-                }
-                printf("got control start\n");
+                print_dnstap(dnswire_reader_dnstap(reader));
                 break;
-
-            case tinyframe_have_control_field:
-                /*
-                 * We have a control field, so lets check that it's a
-                 * `content type` and the content we want is
-                 * `protobuf:dnstap.Dnstap`.
-                 */
-                if (reader.control_field.type != TINYFRAME_CONTROL_FIELD_CONTENT_TYPE
-                    || strncmp("protobuf:dnstap.Dnstap", (const char*)reader.control_field.data, reader.control_field.length)) {
-                    fprintf(stderr, "Not content type dnstap\n");
-                    uv_close((uv_handle_t*)handle, 0);
-                    return;
-                }
-                printf("got content type DNSTAP\n");
+            case dnswire_again:
+            case dnswire_need_more:
                 break;
-
-            case tinyframe_have_frame: {
+            case dnswire_endofdata:
                 /*
-                 * We got a frame, lets decode and print the DNSTAP content.
+                 * The remote end sent a control stop or finish.
                  */
-
-                struct dnstap d = DNSTAP_INITIALIZER;
-
-                /*
-                 * First we decode the DNSTAP protobuf message.
-                 */
-
-                if (dnstap_decode_protobuf(&d, reader.frame.data, reader.frame.length)) {
-                    fprintf(stderr, "dnstap_decode_protobuf() failed\n");
-                    return;
-                }
-
-                /*
-                 * Now we print the DNSTAP message.
-                 */
-
-                print_dnstap(&d);
-
-                /*
-                 * And finally we cleanup protobuf allocations.
-                 */
-
-                dnstap_cleanup(&d);
-                break;
-            }
-
-            case tinyframe_need_more:
-                /*
-                 * We need more bytes, leave this function to let libuv
-                 * handle more incoming data.
-                 */
-                return;
-
-            case tinyframe_error:
-                fprintf(stderr, "tinyframe_read() error\n");
                 uv_close((uv_handle_t*)handle, 0);
                 return;
-
-            case tinyframe_stopped:
-                printf("stopped\n");
-                uv_close((uv_handle_t*)handle, 0);
-                return;
-
-            case tinyframe_finished:
-                printf("finished\n");
-                uv_close((uv_handle_t*)handle, 0);
-                return;
-
             default:
-                fprintf(stderr, "tinyframe_read() unexpected result returned\n");
+                fprintf(stderr, "dnswire_reader_fread() error\n");
                 uv_close((uv_handle_t*)handle, 0);
                 return;
-            }
-
-            /*
-             * If we processed any content in the buffer we might have some left
-             * so we move what's left to the start of the buffer.
-             */
-
-            if (reader.bytes_read > have) {
-                fprintf(stderr, "tinyframe problem, bytes processed more then we had\n");
-                uv_close((uv_handle_t*)handle, 0);
-                return;
-            }
-
-            have -= reader.bytes_read;
-
-            if (have) {
-                memmove(rbuf, &rbuf[reader.bytes_read], have);
             }
         }
     }
@@ -174,6 +91,16 @@ int main(int argc, const char* argv[])
 {
     if (argc < 2) {
         fprintf(stderr, "usage: client_receiver_uv <IP> <port>\n");
+        return 1;
+    }
+
+    /*
+     * We first initialize the reader and check that it can allocate the
+     * buffers it needs.
+     */
+
+    if (dnswire_reader_init(&reader) != dnswire_ok) {
+        fprintf(stderr, "Unable to initialize dnswire reader\n");
         return 1;
     }
 

--- a/examples/receiver.c
+++ b/examples/receiver.c
@@ -1,0 +1,222 @@
+#include <tinyframe/tinyframe.h>
+
+#include <stdio.h>
+#include <errno.h>
+#include <arpa/inet.h>
+#include <stdlib.h>
+#include <sys/socket.h>
+#include <netinet/in.h>
+
+#include "print_dnstap.c"
+
+void handle_client(int fd)
+{
+    /*
+     * As we will be receiving we need to support getting half a frame
+     * and continuing on that so we do a loop where we call
+     * `tinyframe_read()` and when it says it needs more bytes we do
+     * a `recv()` on the socket.
+     *
+     * As we call `tinyframe_read()` the first time without any data
+     * (`have` == 0) it will return that it needs more.
+     */
+
+    struct tinyframe_reader reader = TINYFRAME_READER_INITIALIZER;
+
+    ssize_t               r;
+    size_t                have = 0;
+    uint8_t               buf[4096];
+    enum tinyframe_result res;
+
+    while (1) {
+        switch ((res = tinyframe_read(&reader, buf, have))) {
+        case tinyframe_have_control:
+            /*
+             * If we get a control frame we check that it's a start one,
+             * this code can be extended with checks that you only get one
+             * start frame and it's the first you get.
+             */
+            if (reader.control.type != TINYFRAME_CONTROL_START) {
+                fprintf(stderr, "Not a control type start\n");
+                return;
+            }
+            printf("got control start\n");
+            break;
+
+        case tinyframe_have_control_field:
+            /*
+             * We have a control field, so lets check that it's a
+             * `content type` and the content we want is
+             * `protobuf:dnstap.Dnstap`.
+             */
+            if (reader.control_field.type != TINYFRAME_CONTROL_FIELD_CONTENT_TYPE
+                || strncmp("protobuf:dnstap.Dnstap", (const char*)reader.control_field.data, reader.control_field.length)) {
+                fprintf(stderr, "Not content type dnstap\n");
+                return;
+            }
+            printf("got content type DNSTAP\n");
+            break;
+
+        case tinyframe_have_frame: {
+            /*
+             * We got a frame, lets decode and print the DNSTAP content.
+             */
+
+            struct dnstap d = DNSTAP_INITIALIZER;
+
+            /*
+             * First we decode the DNSTAP protobuf message.
+             */
+
+            if (dnstap_decode_protobuf(&d, reader.frame.data, reader.frame.length)) {
+                fprintf(stderr, "dnstap_decode_protobuf() failed\n");
+                return;
+            }
+
+            /*
+             * Now we print the DNSTAP message.
+             */
+
+            print_dnstap(&d);
+
+            /*
+             * And finally we cleanup protobuf allocations.
+             */
+
+            dnstap_cleanup(&d);
+            break;
+        }
+
+        case tinyframe_need_more:
+            /*
+             * We need more bytes! Let's try and receive some.
+             *
+             * NOTE: This will add bytes to those we already have.
+             */
+            if (have >= sizeof(buf)) {
+                fprintf(stderr, "needed more but buffer was full\n");
+                return;
+            }
+
+            if ((r = recv(fd, &buf[have], sizeof(buf) - have, 0)) < 1) {
+                if (r < 0) {
+                    fprintf(stderr, "read() failed: %s\n", strerror(errno));
+                }
+                return;
+            }
+
+            printf("received %zd bytes\n", r);
+            have += r;
+            break;
+
+        case tinyframe_error:
+            fprintf(stderr, "tinyframe_read() error\n");
+            return;
+
+        case tinyframe_stopped:
+            printf("stopped\n");
+            return;
+
+        case tinyframe_finished:
+            printf("finished\n");
+            return;
+
+        default:
+            fprintf(stderr, "tinyframe_read() unexpected result returned\n");
+            return;
+        }
+
+        /*
+         * If we processed any content in the buffer we might have some left
+         * so we move what's left to the start of the buffer.
+         */
+        if (res != tinyframe_need_more) {
+            if (reader.bytes_read > have) {
+                fprintf(stderr, "tinyframe problem, bytes processed more then we had\n");
+                return;
+            }
+
+            have -= reader.bytes_read;
+
+            if (have) {
+                memmove(buf, &buf[reader.bytes_read], have);
+            }
+        }
+    }
+}
+
+int main(int argc, const char* argv[])
+{
+    if (argc < 2) {
+        fprintf(stderr, "usage: simple_receiver <IP> <port>\n");
+        return 1;
+    }
+
+    /*
+     * We setup and listen on the IP and port given on command line.
+     */
+
+    struct sockaddr_storage addr_store;
+    struct sockaddr_in*     addr = (struct sockaddr_in*)&addr_store;
+    socklen_t               addrlen;
+
+    if (strchr(argv[1], ':')) {
+        addr->sin_family = AF_INET6;
+        addrlen          = sizeof(struct sockaddr_in6);
+    } else {
+        addr->sin_family = AF_INET;
+        addrlen          = sizeof(struct sockaddr_in);
+    }
+
+    if (inet_pton(addr->sin_family, argv[1], &addr->sin_addr) != 1) {
+        fprintf(stderr, "inet_pton(%s) failed: %s\n", argv[1], strerror(errno));
+        return 1;
+    }
+
+    addr->sin_port = atoi(argv[2]);
+
+    int sockfd = socket(addr->sin_family, SOCK_STREAM, IPPROTO_TCP);
+    if (sockfd == -1) {
+        fprintf(stderr, "socket() failed: %s\n", strerror(errno));
+        return 1;
+    }
+    printf("socket\n");
+
+    if (bind(sockfd, (struct sockaddr*)addr, addrlen)) {
+        fprintf(stderr, "bind() failed: %s\n", strerror(errno));
+        close(sockfd);
+        return 1;
+    }
+    printf("bind\n");
+
+    if (listen(sockfd, 0)) {
+        fprintf(stderr, "listen() failed: %s\n", strerror(errno));
+        close(sockfd);
+        return 1;
+    }
+    printf("listen\n");
+
+    int clifd = accept(sockfd, 0, 0);
+    if (clifd < 0) {
+        fprintf(stderr, "accept() failed: %s\n", strerror(errno));
+        close(sockfd);
+        return 1;
+    }
+    printf("accept\n");
+
+    /*
+     * We have accepted connection from the sender!
+     */
+
+    handle_client(clifd);
+
+    /*
+     * Time to exit, let's shutdown and close the sockets.
+     */
+
+    shutdown(clifd, SHUT_RDWR);
+    close(clifd);
+    close(sockfd);
+
+    return 0;
+}

--- a/examples/sender.c
+++ b/examples/sender.c
@@ -1,0 +1,177 @@
+#include <dnswire/dnstap.h>
+#include <tinyframe/tinyframe.h>
+
+#include <arpa/inet.h>
+#include <errno.h>
+#include <stdio.h>
+#include <string.h>
+#include <stdlib.h>
+
+#include "create_dnstap.c"
+
+static char content_type[] = "protobuf:dnstap.Dnstap";
+
+int send_frame(int fd, const uint8_t* buf, size_t len)
+{
+    size_t  sent = 0;
+    ssize_t w;
+
+    while (sent < len) {
+        if ((w = send(fd, &buf[sent], len - sent, 0)) < 1) {
+            if (w < 0) {
+                fprintf(stderr, "write() failed: %s\n", strerror(errno));
+            }
+            return 1;
+        }
+
+        printf("sent %zd bytes\n", w);
+
+        sent += w;
+    }
+
+    return 0;
+}
+
+void handle_client(int fd)
+{
+    /*
+     * We now create each of the needed frames and sends them one by one.
+     */
+
+    struct tinyframe_writer writer = TINYFRAME_WRITER_INITIALIZER;
+
+    /*
+     * We create a buffer that holds a control frame, we do not need to
+     * hold the data in this buffer because we will use the data buffer
+     * for that.
+     */
+
+    uint8_t out[TINYFRAME_CONTROL_FRAME_LENGTH_MAX];
+    size_t  len = sizeof(out);
+
+    /*
+     * First we write, to the buffer, a control start with a content type
+     * control field for the DNSTAP protobuf content type.
+     *
+     * Then we send it.
+     */
+
+    if (tinyframe_write_control_start(&writer, out, len, content_type, sizeof(content_type) - 1) != tinyframe_ok) {
+        fprintf(stderr, "tinyframe_write_control_start() failed\n");
+        return;
+    }
+    printf("sending control start and content type\n");
+    if (send_frame(fd, out, writer.bytes_wrote)) {
+        return;
+    }
+
+    /*
+     * Now we create a DNSTAP message.
+     */
+
+    struct dnstap d = create_dnstap("simple_sender");
+
+    /*
+     * Now that the message is prepared we can begin encapsulating it in
+     * protobuf and Frame Streams.
+     *
+     * First we ask what the encoded size of the protobuf message would be
+     * and then we allocate a buffer with of that size plus the size of
+     * a Frame Streams frame header.
+     *
+     * Then we encode the DNSTAP message and put it after the frame header
+     * and call `tinyframe_set_header()` to set the header.
+     */
+
+    size_t  frame_len = dnstap_encode_protobuf_size(&d);
+    uint8_t frame[TINYFRAME_HEADER_SIZE + frame_len];
+    dnstap_encode_protobuf(&d, &frame[TINYFRAME_HEADER_SIZE]);
+    tinyframe_set_header(frame, frame_len);
+
+    /*
+     * Then we write, to the buffer, the data frame with the encoded DNSTAP
+     * message and the included Frame Streams header.
+     *
+     * Then we send it.
+     */
+
+    printf("sending DNSTAP\n");
+    if (send_frame(fd, frame, sizeof(frame))) {
+        return;
+    }
+
+    /*
+     * Lastly we write, to the buffer, a control stop to indicate the end.
+     *
+     * Then we send it.
+     */
+
+    if (tinyframe_write_control_stop(&writer, out, len) != tinyframe_ok) {
+        fprintf(stderr, "tinyframe_write_control_stop() failed\n");
+        return;
+    }
+    printf("sending control stop\n");
+    if (send_frame(fd, out, writer.bytes_wrote)) {
+        return;
+    }
+}
+
+int main(int argc, const char* argv[])
+{
+    if (argc < 2) {
+        fprintf(stderr, "usage: simple_receiver <IP> <port>\n");
+        return 1;
+    }
+
+    /*
+     * We setup and connect to the IP and port given on command line.
+     */
+
+    struct sockaddr_storage addr_store;
+    struct sockaddr_in*     addr = (struct sockaddr_in*)&addr_store;
+    socklen_t               addrlen;
+
+    if (strchr(argv[1], ':')) {
+        addr->sin_family = AF_INET6;
+        addrlen          = sizeof(struct sockaddr_in6);
+    } else {
+        addr->sin_family = AF_INET;
+        addrlen          = sizeof(struct sockaddr_in);
+    }
+
+    if (inet_pton(addr->sin_family, argv[1], &addr->sin_addr) != 1) {
+        fprintf(stderr, "inet_pton(%s) failed: %s\n", argv[1], strerror(errno));
+        return 1;
+    }
+
+    addr->sin_port = atoi(argv[2]);
+
+    int sockfd = socket(addr->sin_family, SOCK_STREAM, IPPROTO_TCP);
+    if (sockfd == -1) {
+        fprintf(stderr, "socket() failed: %s\n", strerror(errno));
+        return 1;
+    }
+    printf("socket\n");
+
+    if (connect(sockfd, (struct sockaddr*)addr, addrlen)) {
+        fprintf(stderr, "connect() failed: %s\n", strerror(errno));
+        close(sockfd);
+        return 1;
+    }
+    printf("connect\n");
+
+    /*
+     * We are now connected!
+     */
+
+    handle_client(sockfd);
+
+    /*
+     * Time to exit, let's shutdown and close the sockets.
+     */
+
+    shutdown(sockfd, SHUT_RDWR);
+    close(sockfd);
+
+    return 0;
+}

--- a/examples/simple_reader.c
+++ b/examples/simple_reader.c
@@ -23,8 +23,18 @@ int main(int argc, const char* argv[])
         return 1;
     }
 
+    /*
+     * We now initialize the reader and check that it can allocate the
+     * buffers it needs.
+     */
+
     struct dnswire_reader reader = DNSWIRE_READER_INITIALIZER;
     int                   done   = 0;
+
+    if (dnswire_reader_init(&reader) != dnswire_ok) {
+        fprintf(stderr, "Unable to initialize dnswire reader\n");
+        return 1;
+    }
 
     /*
      * We now loop until we have a DNSTAP message, the stream was stopped
@@ -48,7 +58,7 @@ int main(int argc, const char* argv[])
         }
     }
 
-    dnswire_reader_cleanup(reader);
+    dnswire_reader_destroy(reader);
     fclose(fp);
 
     return 0;

--- a/examples/simple_receiver.c
+++ b/examples/simple_receiver.c
@@ -1,4 +1,4 @@
-#include <tinyframe/tinyframe.h>
+#include <dnswire/reader.h>
 
 #include <stdio.h>
 #include <errno.h>
@@ -9,146 +9,22 @@
 
 #include "print_dnstap.c"
 
-void handle_client(int fd)
-{
-    /*
-     * As we will be receiving we need to support getting half a frame
-     * and continuing on that so we do a loop where we call
-     * `tinyframe_read()` and when it says it needs more bytes we do
-     * a `recv()` on the socket.
-     *
-     * As we call `tinyframe_read()` the first time without any data
-     * (`have` == 0) it will return that it needs more.
-     */
-
-    struct tinyframe_reader reader = TINYFRAME_READER_INITIALIZER;
-
-    ssize_t               r;
-    size_t                have = 0;
-    uint8_t               buf[4096];
-    enum tinyframe_result res;
-
-    while (1) {
-        switch ((res = tinyframe_read(&reader, buf, have))) {
-        case tinyframe_have_control:
-            /*
-             * If we get a control frame we check that it's a start one,
-             * this code can be extended with checks that you only get one
-             * start frame and it's the first you get.
-             */
-            if (reader.control.type != TINYFRAME_CONTROL_START) {
-                fprintf(stderr, "Not a control type start\n");
-                return;
-            }
-            printf("got control start\n");
-            break;
-
-        case tinyframe_have_control_field:
-            /*
-             * We have a control field, so lets check that it's a
-             * `content type` and the content we want is
-             * `protobuf:dnstap.Dnstap`.
-             */
-            if (reader.control_field.type != TINYFRAME_CONTROL_FIELD_CONTENT_TYPE
-                || strncmp("protobuf:dnstap.Dnstap", (const char*)reader.control_field.data, reader.control_field.length)) {
-                fprintf(stderr, "Not content type dnstap\n");
-                return;
-            }
-            printf("got content type DNSTAP\n");
-            break;
-
-        case tinyframe_have_frame: {
-            /*
-             * We got a frame, lets decode and print the DNSTAP content.
-             */
-
-            struct dnstap d = DNSTAP_INITIALIZER;
-
-            /*
-             * First we decode the DNSTAP protobuf message.
-             */
-
-            if (dnstap_decode_protobuf(&d, reader.frame.data, reader.frame.length)) {
-                fprintf(stderr, "dnstap_decode_protobuf() failed\n");
-                return;
-            }
-
-            /*
-             * Now we print the DNSTAP message.
-             */
-
-            print_dnstap(&d);
-
-            /*
-             * And finally we cleanup protobuf allocations.
-             */
-
-            dnstap_cleanup(&d);
-            break;
-        }
-
-        case tinyframe_need_more:
-            /*
-             * We need more bytes! Let's try and receive some.
-             *
-             * NOTE: This will add bytes to those we already have.
-             */
-            if (have >= sizeof(buf)) {
-                fprintf(stderr, "needed more but buffer was full\n");
-                return;
-            }
-
-            if ((r = recv(fd, &buf[have], sizeof(buf) - have, 0)) < 1) {
-                if (r < 0) {
-                    fprintf(stderr, "read() failed: %s\n", strerror(errno));
-                }
-                return;
-            }
-
-            printf("received %zd bytes\n", r);
-            have += r;
-            break;
-
-        case tinyframe_error:
-            fprintf(stderr, "tinyframe_read() error\n");
-            return;
-
-        case tinyframe_stopped:
-            printf("stopped\n");
-            return;
-
-        case tinyframe_finished:
-            printf("finished\n");
-            return;
-
-        default:
-            fprintf(stderr, "tinyframe_read() unexpected result returned\n");
-            return;
-        }
-
-        /*
-         * If we processed any content in the buffer we might have some left
-         * so we move what's left to the start of the buffer.
-         */
-        if (res != tinyframe_need_more) {
-            if (reader.bytes_read > have) {
-                fprintf(stderr, "tinyframe problem, bytes processed more then we had\n");
-                return;
-            }
-
-            have -= reader.bytes_read;
-
-            if (have) {
-                memmove(buf, &buf[reader.bytes_read], have);
-            }
-        }
-    }
-}
-
 int main(int argc, const char* argv[])
 {
     if (argc < 2) {
         fprintf(stderr, "usage: simple_receiver <IP> <port>\n");
+        return 1;
+    }
+
+    /*
+     * We first initialize the reader and check that it can allocate the
+     * buffers it needs.
+     */
+
+    struct dnswire_reader reader = DNSWIRE_READER_INITIALIZER;
+
+    if (dnswire_reader_init(&reader) != dnswire_ok) {
+        fprintf(stderr, "Unable to initialize dnswire reader\n");
         return 1;
     }
 
@@ -206,9 +82,33 @@ int main(int argc, const char* argv[])
 
     /*
      * We have accepted connection from the sender!
+     *
+     * We now loop until we have a DNSTAP message, the stream was stopped
+     * or we got an error.
      */
 
-    handle_client(clifd);
+    int done = 0;
+
+    printf("receiving...\n");
+    while (!done) {
+        switch (dnswire_reader_read(&reader, clifd)) {
+        case dnswire_have_dnstap:
+            print_dnstap(dnswire_reader_dnstap(reader));
+            break;
+        case dnswire_again:
+        case dnswire_need_more:
+            break;
+        case dnswire_endofdata:
+            printf("stopped\n");
+            done = 1;
+            break;
+        default:
+            fprintf(stderr, "dnswire_reader_read() error\n");
+            done = 1;
+        }
+    }
+
+    dnswire_reader_destroy(reader);
 
     /*
      * Time to exit, let's shutdown and close the sockets.

--- a/examples/simple_sender.c
+++ b/examples/simple_sender.c
@@ -1,5 +1,4 @@
-#include <dnswire/dnstap.h>
-#include <tinyframe/tinyframe.h>
+#include <dnswire/writer.h>
 
 #include <arpa/inet.h>
 #include <errno.h>
@@ -9,117 +8,22 @@
 
 #include "create_dnstap.c"
 
-static char content_type[] = "protobuf:dnstap.Dnstap";
-
-int send_frame(int fd, const uint8_t* buf, size_t len)
-{
-    size_t  sent = 0;
-    ssize_t w;
-
-    while (sent < len) {
-        if ((w = send(fd, &buf[sent], len - sent, 0)) < 1) {
-            if (w < 0) {
-                fprintf(stderr, "write() failed: %s\n", strerror(errno));
-            }
-            return 1;
-        }
-
-        printf("sent %zd bytes\n", w);
-
-        sent += w;
-    }
-
-    return 0;
-}
-
-void handle_client(int fd)
-{
-    /*
-     * We now create each of the needed frames and sends them one by one.
-     */
-
-    struct tinyframe_writer writer = TINYFRAME_WRITER_INITIALIZER;
-
-    /*
-     * We create a buffer that holds a control frame, we do not need to
-     * hold the data in this buffer because we will use the data buffer
-     * for that.
-     */
-
-    uint8_t out[TINYFRAME_CONTROL_FRAME_LENGTH_MAX];
-    size_t  len = sizeof(out);
-
-    /*
-     * First we write, to the buffer, a control start with a content type
-     * control field for the DNSTAP protobuf content type.
-     *
-     * Then we send it.
-     */
-
-    if (tinyframe_write_control_start(&writer, out, len, content_type, sizeof(content_type) - 1) != tinyframe_ok) {
-        fprintf(stderr, "tinyframe_write_control_start() failed\n");
-        return;
-    }
-    printf("sending control start and content type\n");
-    if (send_frame(fd, out, writer.bytes_wrote)) {
-        return;
-    }
-
-    /*
-     * Now we create a DNSTAP message.
-     */
-
-    struct dnstap d = create_dnstap("simple_sender");
-
-    /*
-     * Now that the message is prepared we can begin encapsulating it in
-     * protobuf and Frame Streams.
-     *
-     * First we ask what the encoded size of the protobuf message would be
-     * and then we allocate a buffer with of that size plus the size of
-     * a Frame Streams frame header.
-     *
-     * Then we encode the DNSTAP message and put it after the frame header
-     * and call `tinyframe_set_header()` to set the header.
-     */
-
-    size_t  frame_len = dnstap_encode_protobuf_size(&d);
-    uint8_t frame[TINYFRAME_HEADER_SIZE + frame_len];
-    dnstap_encode_protobuf(&d, &frame[TINYFRAME_HEADER_SIZE]);
-    tinyframe_set_header(frame, frame_len);
-
-    /*
-     * Then we write, to the buffer, the data frame with the encoded DNSTAP
-     * message and the included Frame Streams header.
-     *
-     * Then we send it.
-     */
-
-    printf("sending DNSTAP\n");
-    if (send_frame(fd, frame, sizeof(frame))) {
-        return;
-    }
-
-    /*
-     * Lastly we write, to the buffer, a control stop to indicate the end.
-     *
-     * Then we send it.
-     */
-
-    if (tinyframe_write_control_stop(&writer, out, len) != tinyframe_ok) {
-        fprintf(stderr, "tinyframe_write_control_stop() failed\n");
-        return;
-    }
-    printf("sending control stop\n");
-    if (send_frame(fd, out, writer.bytes_wrote)) {
-        return;
-    }
-}
-
 int main(int argc, const char* argv[])
 {
     if (argc < 2) {
         fprintf(stderr, "usage: simple_receiver <IP> <port>\n");
+        return 1;
+    }
+
+    /*
+     * We first initialize the writer and check that it can allocate the
+     * buffers it needs.
+     */
+
+    struct dnswire_writer writer = DNSWIRE_WRITER_INITIALIZER;
+
+    if (dnswire_writer_init(&writer) != dnswire_ok) {
+        fprintf(stderr, "Unable to initialize dnswire writer\n");
         return 1;
     }
 
@@ -162,9 +66,53 @@ int main(int argc, const char* argv[])
 
     /*
      * We are now connected!
+     *
+     * Now we create a DNSTAP message.
      */
 
-    handle_client(sockfd);
+    struct dnstap d = create_dnstap("simple_sender");
+
+    /*
+     * We set the DNSTAP message the writer should write.
+     */
+
+    dnswire_writer_set_dnstap(writer, &d);
+
+    /*
+     * We now loop and wait for the DNSTAP message to be written.
+     */
+
+    int done = 0;
+
+    printf("sending...\n");
+    while (!done) {
+        switch (dnswire_writer_write(&writer, sockfd)) {
+        case dnswire_ok:
+            /*
+             * The DNSTAP message was written successfully, we can now set
+             * a new DNSTAP message for the writer or stop the stream.
+             *
+             * This stops the stream, loop again until it's stopped.
+             */
+            printf("sent, stopping...\n");
+            dnswire_writer_stop(&writer);
+            break;
+        case dnswire_again:
+            break;
+        case dnswire_endofdata:
+            /*
+             * The stream is stopped, we're done!
+             */
+            printf("stopped\n");
+            done = 1;
+            break;
+        default:
+            fprintf(stderr, "dnswire_writer_write() error\n");
+            done = 1;
+        }
+    }
+
+    dnswire_writer_destroy(writer);
 
     /*
      * Time to exit, let's shutdown and close the sockets.

--- a/examples/simple_writer.c
+++ b/examples/simple_writer.c
@@ -24,22 +24,34 @@ int main(int argc, const char* argv[])
     }
 
     /*
+     * We first initialize the writer and check that it can allocate the
+     * buffers it needs.
+     */
+
+    struct dnswire_writer writer = DNSWIRE_WRITER_INITIALIZER;
+
+    if (dnswire_writer_init(&writer) != dnswire_ok) {
+        fprintf(stderr, "Unable to initialize dnswire writer\n");
+        return 1;
+    }
+
+    /*
      * Now we create a DNSTAP message.
      */
 
     struct dnstap d = create_dnstap("simple_writer");
 
-    struct dnswire_writer writer = DNSWIRE_WRITER_INITIALIZER;
-    int                   done   = 0;
-
     /*
      * We set the DNSTAP message the writer should write.
      */
+
     dnswire_writer_set_dnstap(writer, &d);
 
     /*
      * We now loop and wait for the DNSTAP message to be written.
      */
+
+    int done = 0;
 
     while (!done) {
         switch (dnswire_writer_fwrite(&writer, fp)) {
@@ -66,7 +78,7 @@ int main(int argc, const char* argv[])
         }
     }
 
-    dnswire_writer_cleanup(writer);
+    dnswire_writer_destroy(writer);
     fclose(fp);
     return 0;
 }

--- a/src/dnswire/writer.h
+++ b/src/dnswire/writer.h
@@ -27,31 +27,42 @@
 #ifndef __dnswire_h_writer
 #define __dnswire_h_writer 1
 
+/*
+ * Attributes:
+ * - size: The current size of the buffer
+ * - inc: How much the buffer will be increased by if more spare is needed
+ * - max: The maximum size the buffer is allowed to have
+ * - at: Where in the buffer we are encoding to (end of data)
+ * - left: How much data that is still left in the buffer before `at`
+ */
 struct dnswire_writer {
     struct dnswire_encoder encoder;
     uint8_t*               buf;
     size_t                 size, inc, max, at, left;
 };
 
-#define DNSWIRE_WRITER_INITIALIZER                   \
-    {                                                \
-        .encoder = DNSWIRE_ENCODER_INITIALIZER,      \
-        .buf     = malloc(DNSWIRE_DEFAULT_BUF_SIZE), \
-        .size    = DNSWIRE_DEFAULT_BUF_SIZE,         \
-        .inc     = DNSWIRE_DEFAULT_BUF_SIZE,         \
-        .max     = DNSWIRE_MAXIMUM_BUF_SIZE,         \
-        .at      = 0,                                \
-        .left    = 0,                                \
+#define DNSWIRE_WRITER_INITIALIZER              \
+    {                                           \
+        .encoder = DNSWIRE_ENCODER_INITIALIZER, \
+        .buf     = 0,                           \
+        .size    = DNSWIRE_DEFAULT_BUF_SIZE,    \
+        .inc     = DNSWIRE_DEFAULT_BUF_SIZE,    \
+        .max     = DNSWIRE_MAXIMUM_BUF_SIZE,    \
+        .at      = 0,                           \
+        .left    = 0,                           \
     }
 
 #define dnswire_writer_set_dnstap(w, d) (w).encoder.dnstap = d
-#define dnswire_writer_cleanup(w) free((w).buf)
+#define dnswire_writer_destroy(w) free((w).buf)
+
+enum dnswire_result dnswire_writer_init(struct dnswire_writer*);
 
 enum dnswire_result dnswire_writer_set_bufsize(struct dnswire_writer*, size_t);
 enum dnswire_result dnswire_writer_set_bufinc(struct dnswire_writer*, size_t);
 enum dnswire_result dnswire_writer_set_bufmax(struct dnswire_writer*, size_t);
 
-enum dnswire_result dnswire_writer_get(struct dnswire_writer*);
+enum dnswire_result dnswire_writer_pop(struct dnswire_writer*, uint8_t**, size_t*);
+enum dnswire_result dnswire_writer_popped(struct dnswire_writer*, size_t);
 enum dnswire_result dnswire_writer_write(struct dnswire_writer*, int);
 enum dnswire_result dnswire_writer_stop(struct dnswire_writer*);
 

--- a/src/test/test1.c
+++ b/src/test/test1.c
@@ -30,7 +30,7 @@ int main(int argc, const char* argv[])
 
     FILE* fp = fopen(argv[1], "r");
     if (!fp) {
-        return 2;
+        return 1;
     }
 
     int rbuf_len = atoi(argv[2]);
@@ -58,7 +58,7 @@ int main(int argc, const char* argv[])
             case tinyframe_have_control_field:
                 printf("control_field type %" PRIu32 " len %" PRIu32 " data: %*s\n", h.control_field.type, h.control_field.length, h.control_field.length, h.control_field.data);
                 if (strncmp("protobuf:dnstap.Dnstap", (const char*)h.control_field.data, h.control_field.length)) {
-                    return 3;
+                    return 1;
                 }
                 break;
             case tinyframe_have_frame:
@@ -71,7 +71,7 @@ int main(int argc, const char* argv[])
                 break;
             case tinyframe_error:
                 printf("error\n");
-                return 2;
+                return 1;
             case tinyframe_stopped:
                 printf("stopped\n");
                 fclose(fp);

--- a/src/test/test2.c
+++ b/src/test/test2.c
@@ -11,7 +11,7 @@ int main(int argc, const char* argv[])
 
     FILE* fp = fopen(argv[1], "w");
     if (!fp) {
-        return 2;
+        return 1;
     }
 
     struct dnstap d = DNSTAP_INITIALIZER;

--- a/src/test/test3.c
+++ b/src/test/test3.c
@@ -6,21 +6,6 @@
 
 #include "print_dnstap.c"
 
-static bool print_dnstap_frame(const uint8_t* data, size_t len_data)
-{
-    struct dnstap d = DNSTAP_INITIALIZER;
-
-    if (dnstap_decode_protobuf(&d, data, len_data)) {
-        fprintf(stderr, "%s: dnstap_decode_protobuf() failed.\n", __func__);
-        return false;
-    }
-
-    print_dnstap(&d);
-    dnstap_cleanup(&d);
-
-    return true;
-}
-
 int main(int argc, const char* argv[])
 {
     if (argc < 3) {
@@ -29,12 +14,15 @@ int main(int argc, const char* argv[])
 
     FILE* fp = fopen(argv[1], "r");
     if (!fp) {
-        return 2;
+        return 1;
     }
 
     int rbuf_len = atoi(argv[2]);
 
     struct dnswire_reader reader = DNSWIRE_READER_INITIALIZER;
+    if (dnswire_reader_init(&reader) != dnswire_ok) {
+        return 1;
+    }
 
     size_t  r;
     uint8_t rbuf[rbuf_len];
@@ -49,14 +37,14 @@ int main(int argc, const char* argv[])
             res = dnswire_need_more;
             break;
         case dnswire_again:
-            res = dnswire_reader_add(&reader, rbuf, 0);
+            res = dnswire_reader_push(&reader, rbuf, 0);
             break;
         case dnswire_need_more:
             r = fread(rbuf, 1, sizeof(rbuf), fp);
             if (r > 0) {
                 printf("read %zu\n", r);
             }
-            res = dnswire_reader_add(&reader, rbuf, r);
+            res = dnswire_reader_push(&reader, rbuf, r);
             break;
         case dnswire_endofdata:
             done = 1;
@@ -67,7 +55,7 @@ int main(int argc, const char* argv[])
         }
     }
 
-    dnswire_reader_cleanup(reader);
+    dnswire_reader_destroy(reader);
     fclose(fp);
     return 0;
 }

--- a/src/test/test4.c
+++ b/src/test/test4.c
@@ -14,10 +14,13 @@ int main(int argc, const char* argv[])
 
     FILE* fp = fopen(argv[1], "w");
     if (!fp) {
-        return 2;
+        return 1;
     }
 
     struct dnswire_writer writer = DNSWIRE_WRITER_INITIALIZER;
+    if (dnswire_writer_init(&writer) != dnswire_ok) {
+        return 1;
+    }
 
     struct dnstap d = DNSTAP_INITIALIZER;
     create_dnstap(&d, "test4");

--- a/src/writer.c
+++ b/src/writer.c
@@ -26,10 +26,24 @@
 #include <assert.h>
 #include <stdlib.h>
 
+enum dnswire_result dnswire_writer_init(struct dnswire_writer* handle)
+{
+    assert(handle);
+
+    if (!handle->buf) {
+        if (handle->buf = malloc(handle->size)) {
+            return dnswire_ok;
+        }
+    }
+
+    return dnswire_error;
+}
+
 enum dnswire_result dnswire_writer_set_bufsize(struct dnswire_writer* handle, size_t size)
 {
     assert(handle);
     assert(size);
+    assert(handle->buf);
 
     if (handle->left > size) {
         // we got data and it doesn't fit in the new size
@@ -40,7 +54,7 @@ enum dnswire_result dnswire_writer_set_bufsize(struct dnswire_writer* handle, si
         return dnswire_error;
     }
 
-    if (handle->at + handle->left > size) {
+    if (handle->at > size) {
         // move what's left to the start
         if (handle->left) {
             memmove(handle->buf, &handle->buf[handle->at], handle->left);
@@ -83,19 +97,116 @@ enum dnswire_result dnswire_writer_set_bufmax(struct dnswire_writer* handle, siz
     return dnswire_ok;
 }
 
-enum dnswire_result dnswire_writer_get(struct dnswire_writer* handle)
+enum dnswire_result dnswire_writer_pop(struct dnswire_writer* handle, uint8_t** data, size_t* len)
 {
-    return dnswire_error;
+    assert(handle);
+    assert(data);
+    assert(len);
+    assert(handle->buf);
+
+    enum dnswire_result res;
+
+    if (handle->left) {
+        // if we have something left, we don't expand the buffer if more
+        // is needed until we have drained it
+
+        if (handle->left < handle->at) {
+            // move what we have to start, make more space
+            memmove(handle->buf, &handle->buf[handle->at - handle->left], handle->left);
+            handle->at = handle->left;
+        }
+
+        res = dnswire_encoder_encode(&handle->encoder, &handle->buf[handle->at], handle->size - handle->at);
+
+        switch (res) {
+        case dnswire_ok:
+        case dnswire_again:
+        case dnswire_endofdata:
+            handle->at += dnswire_encoder_encoded(handle->encoder);
+            handle->left += dnswire_encoder_encoded(handle->encoder);
+            break;
+
+        case dnswire_need_more:
+            break;
+
+        default:
+            return res;
+        }
+
+        *data = handle->buf;
+        *len  = handle->left;
+
+        return res;
+    }
+
+    while (1) {
+        res = dnswire_encoder_encode(&handle->encoder, &handle->buf[handle->at], handle->size - handle->at);
+
+        switch (res) {
+        case dnswire_ok:
+        case dnswire_again:
+        case dnswire_endofdata:
+            handle->at += dnswire_encoder_encoded(handle->encoder);
+            handle->left += dnswire_encoder_encoded(handle->encoder);
+            break;
+
+        case dnswire_need_more:
+            break;
+
+        default:
+            return res;
+        }
+
+        if (res == dnswire_need_more) {
+            if (handle->size < handle->max) {
+                // no space left, expand
+                size_t   size = handle->size + handle->inc > handle->max ? handle->max : handle->size + handle->inc;
+                uint8_t* buf  = realloc(handle->buf, size);
+                if (!buf) {
+                    return dnswire_error;
+                }
+                handle->buf  = buf;
+                handle->size = size;
+                continue;
+            }
+            // already at max size and it's not enough
+            return dnswire_error;
+        }
+        break;
+    }
+
+    *data = &handle->buf[handle->at - handle->left];
+    *len  = handle->left;
+
+    return res;
+}
+
+enum dnswire_result dnswire_writer_popped(struct dnswire_writer* handle, size_t len)
+{
+    assert(handle);
+
+    if (len > handle->left) {
+        return dnswire_error;
+    }
+
+    handle->left -= len;
+    if (!handle->left) {
+        handle->at = 0;
+    }
+
+    return dnswire_ok;
 }
 
 enum dnswire_result dnswire_writer_write(struct dnswire_writer* handle, int fd)
 {
     assert(handle);
+    assert(handle->buf);
 
     enum dnswire_result res;
 
     if (handle->left) {
-        // if we have something left, we don't expand the buffer if more is needed
+        // if we have something left, we don't expand the buffer if more
+        // is needed until we have drained it
 
         if (handle->left < handle->at) {
             // move what we have to start, make more space
@@ -122,8 +233,10 @@ enum dnswire_result dnswire_writer_write(struct dnswire_writer* handle, int fd)
 
         ssize_t nwrote = write(fd, handle->buf, handle->left);
         if (nwrote > 0) {
-            handle->at -= nwrote;
             handle->left -= nwrote;
+            if (!handle->left) {
+                handle->at = 0;
+            }
             return res;
         }
         return dnswire_error;
@@ -165,10 +278,12 @@ enum dnswire_result dnswire_writer_write(struct dnswire_writer* handle, int fd)
         break;
     }
 
-    ssize_t nwrote = write(fd, handle->buf, handle->left);
+    ssize_t nwrote = write(fd, &handle->buf[handle->at - handle->left], handle->left);
     if (nwrote > 0) {
-        handle->at -= nwrote;
         handle->left -= nwrote;
+        if (!handle->left) {
+            handle->at = 0;
+        }
         return res;
     }
     return dnswire_error;


### PR DESCRIPTION
- examples:
  - Add `receiver` and `sender`
  - Use `dnswire_reader` in `client_receiver_uv` and `simple_receiver`
  - Use `dnswire_writer` in `simple_sender`
- reader:
  - Add `dnswire_reader_init()`
  - Rename add to push and added to pushed
  - Add `dnswire_reader_destory()`
  - `dnswire_reader_push()`: Fix issue where `dnswire_decoder_decode()` was called when `left` was zero
- writer:
  - Add `dnswire_writer_init()`
  - Add `dnswire_writer_pop()` and `dnswire_writer_popped()`
  - `dnswire_writer_write()`: Fix issue with `at` being modified after writing