### PR TITLE
Example, fixes

### DIFF
--- a/examples/Makefile.am
+++ b/examples/Makefile.am
@@ -14,7 +14,7 @@ EXTRA_DIST = print_dnstap.c create_dnstap.c
 if BUILD_EXAMPLES
 
 noinst_PROGRAMS = reader writer sender receiver simple_reader simple_writer \
-  simple_sender simple_receiver
+  simple_sender simple_receiver simple_reader_sender
 
 reader_SOURCES = reader.c
 reader_LDADD = ../src/libdnswire.la
@@ -39,6 +39,9 @@ simple_sender_LDADD = ../src/libdnswire.la
 
 simple_receiver_SOURCES = simple_receiver.c
 simple_receiver_LDADD = ../src/libdnswire.la
+
+simple_reader_sender_SOURCES = simple_reader_sender.c
+simple_reader_sender_LDADD = ../src/libdnswire.la
 
 if HAVE_LIBUV
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -10,6 +10,7 @@
 - `writer`: Example of writing DNSTAP using `tinyframe` to show how Frame Streams work
 - `receiver`: Example of receiving a DNSTAP message over a TCP connection and printing it's content, using `tinyframe` to show how Frame Streams work
 - `sender`: Example of constructing a DNSTAP message and sending it over a TCP connection, using `tinyframe` to show how Frame Streams work
+- `simple_reader_sender`: Example of a reader that read DNSTAP from a file and then sends the DNSTAP messages over a TCP connection
 
 ## simple_receiver and simple_sender
 

--- a/examples/print_dnstap.c
+++ b/examples/print_dnstap.c
@@ -64,7 +64,7 @@ static void print_dnstap(const struct dnstap* d)
     }
 
     if (dnstap_type(*d) == DNSTAP_TYPE_MESSAGE && dnstap_has_message(*d)) {
-        printf("message:\n  type: %s\n", DNSTAP_TYPE_STRING[dnstap_type(*d)]);
+        printf("message:\n  type: %s\n", DNSTAP_MESSAGE_TYPE_STRING[dnstap_message_type(*d)]);
 
         if (dnstap_message_has_query_time_sec(*d) && dnstap_message_has_query_time_nsec(*d)) {
             printf("  query_time: %" PRIu64 ".%" PRIu32 "\n", dnstap_message_query_time_sec(*d), dnstap_message_query_time_nsec(*d));

--- a/examples/simple_reader_sender.c
+++ b/examples/simple_reader_sender.c
@@ -1,0 +1,177 @@
+#include <dnswire/reader.h>
+#include <dnswire/writer.h>
+
+#include <stdio.h>
+#include <errno.h>
+#include <string.h>
+#include <arpa/inet.h>
+#include <stdlib.h>
+
+/*
+ * This is a combination of simple_reader and simpler_sender, comments may
+ * be a bit off since they haven't been updated for this.
+ */
+
+int main(int argc, const char* argv[])
+{
+    if (argc < 3) {
+        fprintf(stderr, "usage: simple_reader_sender <file> <IP> <port>\n");
+        return 1;
+    }
+
+    /*
+     * First we open the given file and read all of the content.
+     */
+
+    FILE* fp = fopen(argv[1], "r");
+    if (!fp) {
+        fprintf(stderr, "Unable to open %s: %s\n", argv[1], strerror(errno));
+        return 1;
+    }
+
+    /*
+     * We now initialize the reader and check that it can allocate the
+     * buffers it needs.
+     */
+
+    struct dnswire_reader reader = DNSWIRE_READER_INITIALIZER;
+    int                   done   = 0;
+
+    if (dnswire_reader_init(&reader) != dnswire_ok) {
+        fprintf(stderr, "Unable to initialize dnswire reader\n");
+        return 1;
+    }
+
+    /*
+     * We first initialize the writer and check that it can allocate the
+     * buffers it needs.
+     */
+
+    struct dnswire_writer writer = DNSWIRE_WRITER_INITIALIZER;
+
+    if (dnswire_writer_init(&writer) != dnswire_ok) {
+        fprintf(stderr, "Unable to initialize dnswire writer\n");
+        return 1;
+    }
+
+    /*
+     * We setup and connect to the IP and port given on command line.
+     */
+
+    struct sockaddr_storage addr_store;
+    struct sockaddr_in*     addr = (struct sockaddr_in*)&addr_store;
+    socklen_t               addrlen;
+
+    if (strchr(argv[2], ':')) {
+        addr->sin_family = AF_INET6;
+        addrlen          = sizeof(struct sockaddr_in6);
+    } else {
+        addr->sin_family = AF_INET;
+        addrlen          = sizeof(struct sockaddr_in);
+    }
+
+    if (inet_pton(addr->sin_family, argv[2], &addr->sin_addr) != 1) {
+        fprintf(stderr, "inet_pton(%s) failed: %s\n", argv[2], strerror(errno));
+        return 1;
+    }
+
+    addr->sin_port = ntohs(atoi(argv[3]));
+
+    int sockfd = socket(addr->sin_family, SOCK_STREAM, IPPROTO_TCP);
+    if (sockfd == -1) {
+        fprintf(stderr, "socket() failed: %s\n", strerror(errno));
+        return 1;
+    }
+    printf("socket\n");
+
+    if (connect(sockfd, (struct sockaddr*)addr, addrlen)) {
+        fprintf(stderr, "connect() failed: %s\n", strerror(errno));
+        close(sockfd);
+        return 1;
+    }
+    printf("connect\n");
+
+    /*
+     * We now loop until we have a DNSTAP message, the stream was stopped
+     * or we got an error.
+     */
+
+    int done2 = 0;
+
+    while (!done) {
+        switch (dnswire_reader_fread(&reader, fp)) {
+        case dnswire_have_dnstap:
+            dnswire_writer_set_dnstap(writer, dnswire_reader_dnstap(reader));
+
+            printf("sending...\n");
+            done2 = 0;
+            while (!done2) {
+                switch (dnswire_writer_write(&writer, sockfd)) {
+                case dnswire_ok:
+                    /*
+                     * The DNSTAP message was written successfully, we can now set
+                     * a new DNSTAP message for the writer or stop the stream.
+                     */
+                    printf("sent\n");
+                    done2 = 1;
+                    break;
+                case dnswire_again:
+                    break;
+                default:
+                    fprintf(stderr, "dnswire_writer_write() error\n");
+                    done = 1;
+                    done2 = 2;
+                }
+            }
+            break;
+        case dnswire_again:
+        case dnswire_need_more:
+            break;
+        case dnswire_endofdata:
+            done = 1;
+            break;
+        default:
+            fprintf(stderr, "dnswire_reader_fread() error\n");
+            done = 1;
+        }
+    }
+
+    if (done != 2) {
+        /*
+         * This stops the stream, loop again until it's stopped.
+         */
+        printf("stopping...\n");
+        dnswire_writer_stop(&writer);
+        done2 = 0;
+        while (!done2) {
+            switch (dnswire_writer_write(&writer, sockfd)) {
+            case dnswire_again:
+                break;
+            case dnswire_endofdata:
+                /*
+                 * The stream is stopped, we're done!
+                 */
+                printf("stopped\n");
+                done2 = 1;
+                break;
+            default:
+                fprintf(stderr, "dnswire_writer_write() error\n");
+                done2 = 1;
+            }
+        }
+    }
+
+    dnswire_writer_destroy(writer);
+
+    /*
+     * Time to exit, let's shutdown and close the sockets.
+     */
+
+    shutdown(sockfd, SHUT_RDWR);
+    close(sockfd);
+
+    dnswire_reader_destroy(reader);
+    fclose(fp);
+
+    return 0;
+}

--- a/examples/simple_receiver.c
+++ b/examples/simple_receiver.c
@@ -49,7 +49,7 @@ int main(int argc, const char* argv[])
         return 1;
     }
 
-    addr->sin_port = atoi(argv[2]);
+    addr->sin_port = ntohs(atoi(argv[2]));
 
     int sockfd = socket(addr->sin_family, SOCK_STREAM, IPPROTO_TCP);
     if (sockfd == -1) {

--- a/examples/simple_sender.c
+++ b/examples/simple_sender.c
@@ -48,7 +48,7 @@ int main(int argc, const char* argv[])
         return 1;
     }
 
-    addr->sin_port = atoi(argv[2]);
+    addr->sin_port = ntohs(atoi(argv[2]));
 
     int sockfd = socket(addr->sin_family, SOCK_STREAM, IPPROTO_TCP);
     if (sockfd == -1) {

--- a/src/test/print_dnstap.c
+++ b/src/test/print_dnstap.c
@@ -59,7 +59,7 @@ static void print_dnstap(const struct dnstap* d)
     }
 
     if (dnstap_type(*d) == DNSTAP_TYPE_MESSAGE && dnstap_has_message(*d)) {
-        printf("message:\n  type: %s\n", DNSTAP_TYPE_STRING[dnstap_type(*d)]);
+        printf("message:\n  type: %s\n", DNSTAP_MESSAGE_TYPE_STRING[dnstap_message_type(*d)]);
 
         if (dnstap_message_has_query_time_sec(*d) && dnstap_message_has_query_time_nsec(*d)) {
             printf("  query_time: %" PRIu64 ".%" PRIu32 "\n", dnstap_message_query_time_sec(*d), dnstap_message_query_time_nsec(*d));

--- a/src/test/test1.gold
+++ b/src/test/test1.gold
@@ -5,7 +5,7 @@ frame len 81
 ---- dnstap
 version: kdig 2.6.5
 message:
-  type: MESSAGE
+  type: TOOL_QUERY
   query_time: 1573730567.83350
   socket_family: INET
   socket_protocol: UDP
@@ -20,7 +20,7 @@ frame len 97
 ---- dnstap
 version: kdig 2.6.5
 message:
-  type: MESSAGE
+  type: TOOL_RESPONSE
   response_time: 1573730567.65816434
   socket_family: INET
   socket_protocol: UDP

--- a/src/test/test2.gold
+++ b/src/test/test2.gold
@@ -6,7 +6,7 @@ frame len 121
 identity: test2
 version: 0.1.0
 message:
-  type: MESSAGE
+  type: TOOL_QUERY
   socket_family: INET
   socket_protocol: UDP
   query_address: 127.0.0.1

--- a/src/test/test3.gold
+++ b/src/test/test3.gold
@@ -2,7 +2,7 @@ read 240
 ---- dnstap
 version: kdig 2.6.5
 message:
-  type: MESSAGE
+  type: TOOL_QUERY
   query_time: 1573730567.83350
   socket_family: INET
   socket_protocol: UDP
@@ -16,7 +16,7 @@ message:
 ---- dnstap
 version: kdig 2.6.5
 message:
-  type: MESSAGE
+  type: TOOL_RESPONSE
   response_time: 1573730567.65816434
   socket_family: INET
   socket_protocol: UDP

--- a/src/test/test4.gold
+++ b/src/test/test4.gold
@@ -3,7 +3,7 @@ read 304
 identity: test4
 version: 0.1.0
 message:
-  type: MESSAGE
+  type: TOOL_QUERY
   socket_family: INET
   socket_protocol: UDP
   query_address: 127.0.0.1
@@ -19,7 +19,7 @@ message:
 identity: test4
 version: 0.1.0
 message:
-  type: MESSAGE
+  type: TOOL_QUERY
   socket_family: INET
   socket_protocol: UDP
   query_address: 127.0.0.1


### PR DESCRIPTION
- Add `example/simple_reader_sender`, a reader that read DNSTAP from a file and then sends the DNSTAP messages over a TCP connection
- `examples`:
  - Fix printing of DNSTAP message type
  - Fix port usage in `sockaddr`
- `tests`: Fix printing of DNSTAP message type