### PR TITLE
bidirectional mode

### DIFF
--- a/src/reader.c
+++ b/src/reader.c
@@ -84,12 +84,16 @@ enum dnswire_result dnswire_reader_allow_bidirectional(struct dnswire_reader* ha
 {
     assert(handle);
 
-    if (allow_bidirectional && !handle->write_buf) {
-        if (!(handle->write_buf = malloc(handle->write_size))) {
-            return dnswire_error;
+    if (allow_bidirectional) {
+        if (!handle->write_buf) {
+            if (!(handle->write_buf = malloc(handle->write_size))) {
+                return dnswire_error;
+            }
         }
 
         handle->encoder.state = dnswire_encoder_control_accept;
+    } else {
+        handle->encoder.state = dnswire_encoder_control_start;
     }
 
     handle->allow_bidirectional = allow_bidirectional;

--- a/src/writer.c
+++ b/src/writer.c
@@ -88,14 +88,18 @@ enum dnswire_result dnswire_writer_set_bidirectional(struct dnswire_writer* hand
 {
     assert(handle);
 
-    if (bidirectional && !handle->read_buf) {
-        if (!(handle->read_buf = malloc(handle->read_size))) {
-            return dnswire_error;
+    if (bidirectional) {
+        if (!handle->read_buf) {
+            if (!(handle->read_buf = malloc(handle->read_size))) {
+                return dnswire_error;
+            }
         }
 
         handle->encoder.state = dnswire_encoder_control_ready;
-        // handle->decoder.state = dnswire_decoder_checking_accept;
         __state(handle, dnswire_writer_encoding_ready);
+    } else {
+        handle->encoder.state = dnswire_encoder_control_start;
+        __state(handle, dnswire_writer_encoding);
     }
 
     handle->bidirectional = bidirectional;


### PR DESCRIPTION
- `reader`/`writer`: Allow the bidirectional mode to be switched/toggled more then once