### PR TITLE
Coverage

### DIFF
--- a/fmt.sh
+++ b/fmt.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-clang-format-4.0 \
+clang-format \
     -style=file \
     -i \
     src/*.c \

--- a/sonar-project.properties.local
+++ b/sonar-project.properties.local
@@ -1,0 +1,1 @@
+sonar.coverage.exclusions=src/test/**, src/*.pb-c.*, src/**/*.pb-c.*

--- a/src/decoder.c
+++ b/src/decoder.c
@@ -196,7 +196,7 @@ enum dnswire_result dnswire_decoder_decode(struct dnswire_decoder* handle, const
         }
 
     case dnswire_decoder_done:
-        return dnswire_error;
+        break;
     }
 
     return dnswire_error;

--- a/src/dnstap.c
+++ b/src/dnstap.c
@@ -99,7 +99,7 @@ int dnstap_decode_protobuf(struct dnstap* dnstap, const uint8_t* data, size_t le
             break;
         default:
             dnstap->message.has_socket_family = false;
-            dnstap->message.socket_family     = (enum _Dnstap__SocketFamily)DNSTAP_MESSAGE_TYPE_UNKNOWN;
+            dnstap->message.socket_family     = (enum _Dnstap__SocketFamily)DNSTAP_SOCKET_FAMILY_UNKNOWN;
         }
 
         switch (dnstap->message.socket_protocol) {
@@ -108,7 +108,7 @@ int dnstap_decode_protobuf(struct dnstap* dnstap, const uint8_t* data, size_t le
             break;
         default:
             dnstap->message.has_socket_protocol = false;
-            dnstap->message.socket_protocol     = (enum _Dnstap__SocketProtocol)DNSTAP_MESSAGE_TYPE_UNKNOWN;
+            dnstap->message.socket_protocol     = (enum _Dnstap__SocketProtocol)DNSTAP_SOCKET_PROTOCOL_UNKNOWN;
         }
     }
 

--- a/src/dnswire/dnstap.h
+++ b/src/dnswire/dnstap.h
@@ -56,7 +56,7 @@ enum dnstap_message_type {
 extern const char* const DNSTAP_MESSAGE_TYPE_STRING[];
 
 enum dnstap_socket_family {
-    DNSTAP_SOCKET_FAMILT_UNKNOWN = 0,
+    DNSTAP_SOCKET_FAMILY_UNKNOWN = 0,
     DNSTAP_SOCKET_FAMILY_INET    = 1,
     DNSTAP_SOCKET_FAMILY_INET6   = 2,
 };

--- a/src/encoder.c
+++ b/src/encoder.c
@@ -123,7 +123,6 @@ enum dnswire_result dnswire_encoder_encode(struct dnswire_encoder* handle, uint8
 
         switch (tinyframe_write_frame(&handle->writer, out, len, frame, sizeof(frame))) {
         case tinyframe_ok:
-            __state(handle, dnswire_encoder_frames);
             return dnswire_ok;
 
         case tinyframe_need_more:
@@ -150,7 +149,7 @@ enum dnswire_result dnswire_encoder_encode(struct dnswire_encoder* handle, uint8
         return dnswire_error;
 
     case dnswire_encoder_done:
-        return dnswire_error;
+        break;
     }
 
     return dnswire_error;

--- a/src/reader.c
+++ b/src/reader.c
@@ -228,7 +228,7 @@ enum dnswire_result dnswire_reader_push(struct dnswire_reader* handle, const uin
             handle->left += handle->pushed;
         }
         __state(handle, dnswire_reader_decoding_control);
-    // fallthrough
+        // fallthrough
 
     case dnswire_reader_decoding_control:
         switch (dnswire_decoder_decode(&handle->decoder, &handle->buf[handle->at], handle->left)) {
@@ -321,7 +321,7 @@ enum dnswire_result dnswire_reader_push(struct dnswire_reader* handle, const uin
         case dnswire_again:
             __state(handle, dnswire_reader_writing_accept);
             break;
-        // fallthrough
+            // fallthrough
 
         default:
             return dnswire_error;
@@ -354,7 +354,7 @@ enum dnswire_result dnswire_reader_push(struct dnswire_reader* handle, const uin
             handle->left += handle->pushed;
         }
         __state(handle, dnswire_reader_decoding);
-    // fallthrough
+        // fallthrough
 
     case dnswire_reader_decoding:
         switch (dnswire_decoder_decode(&handle->decoder, &handle->buf[handle->at], handle->left)) {
@@ -424,7 +424,7 @@ enum dnswire_result dnswire_reader_push(struct dnswire_reader* handle, const uin
         case dnswire_endofdata:
             __state(handle, dnswire_reader_writing_finish);
             break;
-        // fallthrough
+            // fallthrough
 
         default:
             return dnswire_error;
@@ -446,7 +446,7 @@ enum dnswire_result dnswire_reader_push(struct dnswire_reader* handle, const uin
         return dnswire_again;
 
     case dnswire_reader_done:
-        return dnswire_error;
+        break;
     }
 
     return dnswire_error;
@@ -560,7 +560,7 @@ enum dnswire_result dnswire_reader_read(struct dnswire_reader* handle, int fd)
         case dnswire_again:
             __state(handle, dnswire_reader_writing_accept);
             break;
-        // fallthrough
+            // fallthrough
 
         default:
             return dnswire_error;
@@ -665,7 +665,7 @@ enum dnswire_result dnswire_reader_read(struct dnswire_reader* handle, int fd)
         case dnswire_endofdata:
             __state(handle, dnswire_reader_writing_finish);
             break;
-        // fallthrough
+            // fallthrough
 
         default:
             return dnswire_error;
@@ -693,7 +693,7 @@ enum dnswire_result dnswire_reader_read(struct dnswire_reader* handle, int fd)
     }
 
     case dnswire_reader_done:
-        return dnswire_error;
+        break;
     }
 
     return dnswire_error;

--- a/src/test/Makefile.am
+++ b/src/test/Makefile.am
@@ -9,8 +9,9 @@ AM_CFLAGS = -I$(top_srcdir)/src \
   $(protobuf_c_CFLAGS)
 
 check_PROGRAMS = reader_read reader_push writer_write writer_pop \
-  reader_unixsock writer_unixsock
-TESTS = test1.sh test2.sh test3.sh test4.sh test5.sh
+  reader_unixsock writer_unixsock test_dnstap test_encoder test_decoder \
+  test_reader test_writer
+TESTS = test1.sh test2.sh test3.sh test4.sh test5.sh test6.sh
 EXTRA_DIST = create_dnstap.c print_dnstap.c $(TESTS) test.dnstap \
   test1.gold test2.gold test3.gold test4.gold test5.gold
 
@@ -38,11 +39,32 @@ writer_unixsock_SOURCES = writer_unixsock.c
 writer_unixsock_LDADD = ../libdnswire.la
 writer_unixsock_LDFLAGS = $(protobuf_c_LIBS) $(tinyframe_LIBS) -static
 
+test_dnstap_SOURCES = test_dnstap.c
+test_dnstap_LDADD = ../libdnswire.la
+test_dnstap_LDFLAGS = $(protobuf_c_LIBS) $(tinyframe_LIBS) -static
+
+test_encoder_SOURCES = test_encoder.c
+test_encoder_LDADD = ../libdnswire.la
+test_encoder_LDFLAGS = $(protobuf_c_LIBS) $(tinyframe_LIBS) -static
+
+test_decoder_SOURCES = test_decoder.c
+test_decoder_LDADD = ../libdnswire.la
+test_decoder_LDFLAGS = $(protobuf_c_LIBS) $(tinyframe_LIBS) -static
+
+test_reader_SOURCES = test_reader.c
+test_reader_LDADD = ../libdnswire.la
+test_reader_LDFLAGS = $(protobuf_c_LIBS) $(tinyframe_LIBS) -static
+
+test_writer_SOURCES = test_writer.c
+test_writer_LDADD = ../libdnswire.la
+test_writer_LDFLAGS = $(protobuf_c_LIBS) $(tinyframe_LIBS) -static
+
 if ENABLE_GCOV
 gcov-local:
 	for src in $(reader_read_SOURCES) $(reader_push_SOURCES) \
-$(writer_write_SOURCES) $(writer_pop_SOURCES) \
-$(reader_unixsock_SOURCES) $(writer_unixsock_SOURCES); do \
+$(writer_write_SOURCES) $(writer_pop_SOURCES) $(reader_unixsock_SOURCES) \
+$(writer_unixsock_SOURCES) $(test_dnstap_SOURCES) $(test_encoder_SOURCES) \
+$(test_decoder_SOURCES) $(test_reader_SOURCES) $(test_writer_SOURCES); do \
 	  gcov -l -r -s "$(srcdir)" "$$src"; \
 	done
 endif

--- a/src/test/reader_unixsock.c
+++ b/src/test/reader_unixsock.c
@@ -44,6 +44,16 @@ int main(int argc, const char* argv[])
         }
         dnswire_reader_allow_bidirectional(&reader, true);
 
+        // force small buffers to trigger buf resizing
+        reader.write_size = 4;
+        reader.write_inc  = 4;
+        if (dnswire_reader_set_bufsize(&reader, 4) != dnswire_ok) {
+            return 1;
+        }
+        if (dnswire_reader_set_bufinc(&reader, 4) != dnswire_ok) {
+            return 1;
+        }
+
         int done = 0;
 
         while (!done) {

--- a/src/test/test6.sh
+++ b/src/test/test6.sh
@@ -1,0 +1,7 @@
+#!/bin/sh -xe
+
+./test_dnstap
+./test_encoder
+./test_decoder
+./test_reader
+./test_writer

--- a/src/test/test_decoder.c
+++ b/src/test/test_decoder.c
@@ -1,0 +1,33 @@
+#include <dnswire/decoder.h>
+
+#include <assert.h>
+
+#include "create_dnstap.c"
+
+int main(void)
+{
+    uint8_t                buf[1];
+    struct dnswire_decoder d = DNSWIRE_DECODER_INITIALIZER;
+
+    // decoder * need more
+    d.state = dnswire_decoder_reading_control;
+    assert(dnswire_decoder_decode(&d, buf, 1) == dnswire_need_more);
+    d.state = dnswire_decoder_checking_ready;
+    assert(dnswire_decoder_decode(&d, buf, 1) == dnswire_need_more);
+    d.state = dnswire_decoder_checking_accept;
+    assert(dnswire_decoder_decode(&d, buf, 1) == dnswire_need_more);
+    d.state = dnswire_decoder_reading_start;
+    assert(dnswire_decoder_decode(&d, buf, 1) == dnswire_need_more);
+    d.state = dnswire_decoder_checking_start;
+    assert(dnswire_decoder_decode(&d, buf, 1) == dnswire_need_more);
+    d.state = dnswire_decoder_reading_frames;
+    assert(dnswire_decoder_decode(&d, buf, 1) == dnswire_need_more);
+    d.state = dnswire_decoder_checking_finish;
+    assert(dnswire_decoder_decode(&d, buf, 1) == dnswire_need_more);
+
+    // decoder done
+    d.state = dnswire_decoder_done;
+    assert(dnswire_decoder_decode(&d, buf, 1) == dnswire_error);
+
+    return 0;
+}

--- a/src/test/test_dnstap.c
+++ b/src/test/test_dnstap.c
@@ -1,0 +1,60 @@
+#include <dnswire/dnstap.h>
+
+#include <assert.h>
+
+#include "create_dnstap.c"
+
+int main(void)
+{
+    uint8_t       buf[256 * 1024];
+    size_t        s;
+    struct dnstap d = DNSTAP_INITIALIZER;
+    struct dnstap u = DNSTAP_INITIALIZER;
+
+    create_dnstap(&d, "test_dnstap");
+
+    // failed unpack
+    assert(dnstap_decode_protobuf(&u, buf, 1) == 1);
+
+    // invalid dnstap.type
+    d.dnstap.type = (enum _Dnstap__Dnstap__Type)(DNSTAP_TYPE_MESSAGE + 1);
+    s             = dnstap_encode_protobuf_size(&d);
+    assert(s < sizeof(buf));
+    assert(dnstap_encode_protobuf(&d, buf) == s);
+    assert(dnstap_decode_protobuf(&u, buf, s) == 0);
+    assert(u.dnstap.type == (enum _Dnstap__Dnstap__Type)DNSTAP_TYPE_UNKNOWN);
+    dnstap_cleanup(&u);
+    d.dnstap.type = (enum _Dnstap__Dnstap__Type)DNSTAP_TYPE_MESSAGE;
+
+    // invalid message.type
+    d.message.type = (enum _Dnstap__Message__Type)(DNSTAP_MESSAGE_TYPE_TOOL_RESPONSE + 1);
+    s              = dnstap_encode_protobuf_size(&d);
+    assert(s < sizeof(buf));
+    assert(dnstap_encode_protobuf(&d, buf) == s);
+    assert(dnstap_decode_protobuf(&u, buf, s) == 0);
+    assert(u.message.type == (enum _Dnstap__Message__Type)DNSTAP_MESSAGE_TYPE_UNKNOWN);
+    dnstap_cleanup(&u);
+    d.message.type = (enum _Dnstap__Message__Type)DNSTAP_MESSAGE_TYPE_TOOL_QUERY;
+
+    // invalid message.socket_family
+    d.message.socket_family = (enum _Dnstap__SocketFamily)(DNSTAP_SOCKET_FAMILY_INET6 + 1);
+    s                       = dnstap_encode_protobuf_size(&d);
+    assert(s < sizeof(buf));
+    assert(dnstap_encode_protobuf(&d, buf) == s);
+    assert(dnstap_decode_protobuf(&u, buf, s) == 0);
+    assert(u.message.socket_family == (enum _Dnstap__SocketFamily)DNSTAP_SOCKET_FAMILY_UNKNOWN);
+    dnstap_cleanup(&u);
+    d.message.socket_family = (enum _Dnstap__SocketFamily)DNSTAP_SOCKET_FAMILY_INET;
+
+    // invalid message.socket_protocol
+    d.message.socket_protocol = (enum _Dnstap__SocketProtocol)(DNSTAP_SOCKET_PROTOCOL_TCP + 1);
+    s                         = dnstap_encode_protobuf_size(&d);
+    assert(s < sizeof(buf));
+    assert(dnstap_encode_protobuf(&d, buf) == s);
+    assert(dnstap_decode_protobuf(&u, buf, s) == 0);
+    assert(u.message.socket_protocol == (enum _Dnstap__SocketProtocol)DNSTAP_SOCKET_PROTOCOL_UNKNOWN);
+    dnstap_cleanup(&u);
+    d.message.socket_protocol = (enum _Dnstap__SocketProtocol)DNSTAP_SOCKET_PROTOCOL_UDP;
+
+    return 0;
+}

--- a/src/test/test_encoder.c
+++ b/src/test/test_encoder.c
@@ -1,0 +1,41 @@
+#include <dnswire/encoder.h>
+
+#include <assert.h>
+
+#include "create_dnstap.c"
+
+int main(void)
+{
+    uint8_t                buf[1];
+    struct dnswire_encoder e = DNSWIRE_ENCODER_INITIALIZER;
+    struct dnstap          d = DNSTAP_INITIALIZER;
+
+    create_dnstap(&d, "test_encoder");
+
+    // encoder stop at wrong state
+    assert(dnswire_encoder_stop(&e) == dnswire_error);
+
+    // encoder * need more
+    e.state = dnswire_encoder_control_ready;
+    assert(dnswire_encoder_encode(&e, buf, 1) == dnswire_need_more);
+    e.state = dnswire_encoder_control_start;
+    assert(dnswire_encoder_encode(&e, buf, 1) == dnswire_need_more);
+    e.state = dnswire_encoder_control_accept;
+    assert(dnswire_encoder_encode(&e, buf, 1) == dnswire_need_more);
+    e.state = dnswire_encoder_control_finish;
+    assert(dnswire_encoder_encode(&e, buf, 1) == dnswire_need_more);
+    e.state = dnswire_encoder_control_stop;
+    assert(dnswire_encoder_encode(&e, buf, 1) == dnswire_need_more);
+
+    // encoder frame
+    e.state = dnswire_encoder_frames;
+    assert(dnswire_encoder_encode(&e, buf, 1) == dnswire_error);
+    dnswire_encoder_set_dnstap(e, &d);
+    assert(dnswire_encoder_encode(&e, buf, 1) == dnswire_need_more);
+
+    // encoder done
+    e.state = dnswire_encoder_done;
+    assert(dnswire_encoder_encode(&e, buf, 1) == dnswire_error);
+
+    return 0;
+}

--- a/src/test/test_reader.c
+++ b/src/test/test_reader.c
@@ -1,0 +1,73 @@
+#include <dnswire/reader.h>
+
+#include <assert.h>
+
+int main(void)
+{
+    uint8_t               buf[1], buf2[1];
+    size_t                s;
+    struct dnswire_reader r;
+    assert(dnswire_reader_init(&r) == dnswire_ok);
+    assert(dnswire_reader_allow_bidirectional(&r, true) == dnswire_ok);
+
+    // set bufsize
+    r.left = 2;
+    assert(dnswire_reader_set_bufsize(&r, 1) == dnswire_error);
+    r.left = 1;
+    r.at   = 1;
+    assert(dnswire_reader_set_bufsize(&r, 1) == dnswire_ok);
+    r.left = 0;
+    assert(dnswire_reader_set_bufsize(&r, DNSWIRE_MAXIMUM_BUF_SIZE + 1) == dnswire_error);
+    assert(dnswire_reader_set_bufsize(&r, DNSWIRE_DEFAULT_BUF_SIZE) == dnswire_ok);
+
+    // set bufinc
+    assert(dnswire_reader_set_bufinc(&r, DNSWIRE_DEFAULT_BUF_SIZE) == dnswire_ok);
+
+    // set bufmax
+    assert(dnswire_reader_set_bufmax(&r, DNSWIRE_DEFAULT_BUF_SIZE - 1) == dnswire_error);
+    assert(dnswire_reader_set_bufmax(&r, DNSWIRE_MAXIMUM_BUF_SIZE) == dnswire_ok);
+
+    // reader push
+    r.state = dnswire_reader_reading_control;
+    assert(dnswire_reader_push(&r, buf, 0, buf2, &s) == dnswire_need_more);
+    r.state = dnswire_reader_encoding_accept;
+    s       = sizeof(buf2);
+    assert(dnswire_reader_push(&r, buf, 0, buf2, &s) == dnswire_again);
+    r.state = dnswire_reader_reading;
+    assert(dnswire_reader_push(&r, buf, 0, buf2, &s) == dnswire_need_more);
+    r.state = dnswire_reader_encoding_finish;
+    assert(dnswire_reader_push(&r, buf, 0, buf2, &s) == dnswire_again);
+    r.decoder.state = dnswire_decoder_done;
+    r.left          = 1;
+    r.state         = dnswire_reader_decoding_control;
+    assert(dnswire_reader_push(&r, buf, 0, buf2, &s) == dnswire_error);
+    r.state = dnswire_reader_decoding;
+    assert(dnswire_reader_push(&r, buf, 0, buf2, &s) == dnswire_error);
+    r.state = dnswire_reader_done;
+    assert(dnswire_reader_push(&r, buf, 0, buf2, &s) == dnswire_error);
+
+    // reset reader
+    dnswire_reader_destroy(r);
+    assert(dnswire_reader_init(&r) == dnswire_ok);
+    assert(dnswire_reader_allow_bidirectional(&r, true) == dnswire_ok);
+
+    // reader read
+    r.state = dnswire_reader_reading_control;
+    assert(dnswire_reader_read(&r, -1) == dnswire_error);
+    r.state = dnswire_reader_writing_accept;
+    assert(dnswire_reader_read(&r, -1) == dnswire_error);
+    r.state = dnswire_reader_reading;
+    assert(dnswire_reader_read(&r, -1) == dnswire_error);
+    r.state = dnswire_reader_writing_finish;
+    assert(dnswire_reader_read(&r, -1) == dnswire_error);
+    r.decoder.state = dnswire_decoder_done;
+    r.left          = 1;
+    r.state         = dnswire_reader_decoding_control;
+    assert(dnswire_reader_read(&r, -1) == dnswire_error);
+    r.state = dnswire_reader_decoding;
+    assert(dnswire_reader_read(&r, -1) == dnswire_error);
+    r.state = dnswire_reader_done;
+    assert(dnswire_reader_read(&r, -1) == dnswire_error);
+
+    return 0;
+}

--- a/src/test/test_writer.c
+++ b/src/test/test_writer.c
@@ -1,0 +1,94 @@
+#include <dnswire/writer.h>
+
+#include <assert.h>
+
+int main(void)
+{
+    uint8_t               buf[1], buf2[1];
+    size_t                s;
+    struct dnswire_writer w;
+    assert(dnswire_writer_init(&w) == dnswire_ok);
+
+    // set bidirectional
+    assert(dnswire_writer_set_bidirectional(&w, true) == dnswire_ok);
+    assert(dnswire_writer_set_bidirectional(&w, false) == dnswire_ok);
+
+    // set bufsize
+    w.left = 2;
+    assert(dnswire_writer_set_bufsize(&w, 1) == dnswire_error);
+    w.left = 1;
+    w.at   = 1;
+    assert(dnswire_writer_set_bufsize(&w, 1) == dnswire_ok);
+    w.left = 0;
+    assert(dnswire_writer_set_bufsize(&w, DNSWIRE_MAXIMUM_BUF_SIZE + 1) == dnswire_error);
+    assert(dnswire_writer_set_bufsize(&w, DNSWIRE_DEFAULT_BUF_SIZE) == dnswire_ok);
+
+    // set bufinc
+    assert(dnswire_writer_set_bufinc(&w, DNSWIRE_DEFAULT_BUF_SIZE) == dnswire_ok);
+
+    // set bufmax
+    assert(dnswire_writer_set_bufmax(&w, DNSWIRE_DEFAULT_BUF_SIZE - 1) == dnswire_error);
+    assert(dnswire_writer_set_bufmax(&w, DNSWIRE_MAXIMUM_BUF_SIZE) == dnswire_ok);
+
+    // writer pop
+    w.state = dnswire_writer_encoding_ready;
+    s       = sizeof(buf2);
+    assert(dnswire_writer_pop(&w, buf, 1, buf2, &s) == dnswire_again);
+    w.state = dnswire_writer_reading_accept;
+    s       = 0;
+    assert(dnswire_writer_pop(&w, buf, 1, buf2, &s) == dnswire_need_more);
+    s           = sizeof(buf2);
+    w.read_left = 1;
+    assert(dnswire_writer_pop(&w, buf, 1, buf2, &s) == dnswire_need_more);
+    w.state     = dnswire_writer_stopping;
+    w.read_left = 1;
+    assert(dnswire_writer_pop(&w, buf, 1, buf2, &s) == dnswire_again);
+    w.read_left = 0;
+    w.state     = dnswire_writer_reading_finish;
+    s           = 0;
+    assert(dnswire_writer_pop(&w, buf, 1, buf2, &s) == dnswire_need_more);
+    s           = sizeof(buf2);
+    w.read_left = 1;
+    assert(dnswire_writer_pop(&w, buf, 1, buf2, &s) == dnswire_need_more);
+    w.decoder.state = dnswire_decoder_done;
+    w.state         = dnswire_writer_decoding_accept;
+    w.read_left     = 1;
+    assert(dnswire_writer_pop(&w, buf, 1, buf2, &s) == dnswire_error);
+    w.state     = dnswire_writer_decoding_finish;
+    w.read_left = 1;
+    assert(dnswire_writer_pop(&w, buf, 1, buf2, &s) == dnswire_error);
+    w.state = dnswire_writer_done;
+    assert(dnswire_writer_pop(&w, buf, 1, buf2, &s) == dnswire_error);
+
+    // reset writer
+    dnswire_writer_destroy(w);
+    assert(dnswire_writer_init(&w) == dnswire_ok);
+    assert(dnswire_writer_set_bidirectional(&w, true) == dnswire_ok);
+
+    // writer write
+    w.state = dnswire_writer_writing_ready;
+    assert(dnswire_writer_write(&w, -1) == dnswire_error);
+    w.state = dnswire_writer_reading_accept;
+    assert(dnswire_writer_write(&w, -1) == dnswire_error);
+    w.state = dnswire_writer_writing;
+    assert(dnswire_writer_write(&w, -1) == dnswire_error);
+    w.state = dnswire_writer_stopping;
+    w.left  = 1;
+    assert(dnswire_writer_write(&w, -1) == dnswire_error);
+    w.state = dnswire_writer_writing_stop;
+    w.left  = 1;
+    assert(dnswire_writer_write(&w, -1) == dnswire_error);
+    w.left  = 0;
+    w.state = dnswire_writer_reading_finish;
+    assert(dnswire_writer_write(&w, -1) == dnswire_error);
+    w.read_left     = 1;
+    w.decoder.state = dnswire_decoder_done;
+    w.state         = dnswire_writer_decoding_accept;
+    assert(dnswire_writer_write(&w, -1) == dnswire_error);
+    w.state = dnswire_writer_decoding_finish;
+    assert(dnswire_writer_write(&w, -1) == dnswire_error);
+    w.state = dnswire_writer_done;
+    assert(dnswire_writer_write(&w, -1) == dnswire_error);
+
+    return 0;
+}

--- a/src/test/writer_unixsock.c
+++ b/src/test/writer_unixsock.c
@@ -51,6 +51,16 @@ int main(int argc, const char* argv[])
         return 1;
     }
 
+    // force small buffers to trigger buf resizing
+    writer.read_size = 4;
+    writer.read_inc  = 4;
+    if (dnswire_writer_set_bufsize(&writer, 4) != dnswire_ok) {
+        return 1;
+    }
+    if (dnswire_writer_set_bufinc(&writer, 4) != dnswire_ok) {
+        return 1;
+    }
+
     struct dnstap d = DNSTAP_INITIALIZER;
     create_dnstap(&d, "writer_reader_unixsock-1");
 

--- a/src/writer.c
+++ b/src/writer.c
@@ -122,7 +122,7 @@ enum dnswire_result dnswire_writer_set_bufsize(struct dnswire_writer* handle, si
         return dnswire_error;
     }
 
-    if (handle->at > size) {
+    if (handle->at + handle->left > size) {
         // move what's left to the start
         if (handle->left) {
             memmove(handle->buf, &handle->buf[handle->at], handle->left);
@@ -258,7 +258,7 @@ enum dnswire_result dnswire_writer_pop(struct dnswire_writer* handle, uint8_t* d
             handle->left += *in_len;
         }
         __state(handle, dnswire_writer_decoding_accept);
-    // fallthrough
+        // fallthrough
 
     case dnswire_writer_decoding_accept:
         switch (dnswire_decoder_decode(&handle->decoder, &handle->read_buf[handle->read_at], handle->read_left)) {
@@ -351,7 +351,7 @@ enum dnswire_result dnswire_writer_pop(struct dnswire_writer* handle, uint8_t* d
             handle->at = 0;
         }
         __state(handle, dnswire_writer_encoding_stop);
-    // fallthrough
+        // fallthrough
 
     case dnswire_writer_encoding_stop:
         res = _encoding(handle);
@@ -392,7 +392,7 @@ enum dnswire_result dnswire_writer_pop(struct dnswire_writer* handle, uint8_t* d
             handle->left += *in_len;
         }
         __state(handle, dnswire_writer_decoding_finish);
-    // fallthrough
+        // fallthrough
 
     case dnswire_writer_decoding_finish:
         switch (dnswire_decoder_decode(&handle->decoder, &handle->read_buf[handle->read_at], handle->read_left)) {
@@ -600,7 +600,7 @@ enum dnswire_result dnswire_writer_write(struct dnswire_writer* handle, int fd)
             handle->at = 0;
         }
         __state(handle, dnswire_writer_encoding_stop);
-    // fallthrough
+        // fallthrough
 
     case dnswire_writer_encoding_stop:
         res = _encoding(handle);


### PR DESCRIPTION
- Update formatting software and format code
- Exclude tests and generated protobuf code from coverage reporting
- `dnswire_decoder_decode()`: Change switch to hit last return
- `dnstap_decode_protobuf()`: Fix settings unknown socket family and protocol
- `enum dnstap_message_type`: Fix typo of unknown
- `dnswire_encoder_encode()`:
  - Remove state set of same state
  - Change switch to hit last return
- `dnswire_reader_push()`: Change switch to hit last return
- `dnswire_reader_read()`: Change switch to hit last return
- `dnswire_writer_set_bufsize()`: Fix bug with changing buffer size while having something in the buffer
- `test`:
  - Add coverage tests for dnstap, encoder, decoder, reader and writer
  - Change unixsock tests to use smaller buffers and hit buffer growing code